### PR TITLE
add support for array values

### DIFF
--- a/lib/fluent/plugin/filter_viaq_data_model.rb
+++ b/lib/fluent/plugin/filter_viaq_data_model.rb
@@ -95,7 +95,11 @@ module Fluent
     # recursively delete empty fields and empty lists/hashes from thing
     def delempty(thing)
       if thing.respond_to?(:delete_if)
-        thing.delete_if{|k,v| v.nil? || isempty(delempty(v)) || isempty(v)}
+        if thing.kind_of? Hash
+          thing.delete_if{|k,v| v.nil? || isempty(delempty(v)) || isempty(v)}
+        else # assume single element iterable
+          thing.delete_if{|elem| elem.nil? || isempty(delempty(elem)) || isempty(elem)}
+        end
       end
       thing
     end

--- a/test/test_filter_viaq_data_model.rb
+++ b/test/test_filter_viaq_data_model.rb
@@ -192,6 +192,26 @@ class ViaqDataModelFilterTest < Test::Unit::TestCase
       assert_equal(99, rec['h']['i']['m'])
       assert_true(rec['h']['i']['n'])
     end
+    test 'see if fields with a value of numeric 0 are removed or preserved' do
+      msg = {'a'=>{'b'=>{'c'=>{'d'=>{'e'=>'','f'=>{},'g'=>0}}}},'h'=>{'i'=>{'j'=>'','k'=>'l','m'=>0,'n'=>true}}}
+      rec = emit_with_tag('tag', msg)
+      assert_nil(rec['a']['b']['c']['d']['e'])
+      assert_nil(rec['a']['b']['c']['d']['f'])
+      assert_equal(0, rec['a']['b']['c']['d']['g'])
+      assert_equal('l', rec['h']['i']['k'])
+      assert_equal(0, rec['h']['i']['m'])
+      assert_true(rec['h']['i']['n'])
+    end
+    test 'see if fields with array values of numeric values are preserved' do
+      msg = {'a'=>{'b'=>{'c'=>{'d'=>{'e'=>'','f'=>{},'g'=>[99.999]}}}},'h'=>{'i'=>{'j'=>'','k'=>'l','m'=>[88],'n'=>true}}}
+      rec = emit_with_tag('tag', msg)
+      assert_equal([99.999], rec['a']['b']['c']['d']['g'])
+      assert_nil(rec['a']['b']['c']['d']['e'])
+      assert_nil(rec['a']['b']['c']['d']['f'])
+      assert_equal('l', rec['h']['i']['k'])
+      assert_equal([88], rec['h']['i']['m'])
+      assert_true(rec['h']['i']['n'])
+    end
 
   end
 end


### PR DESCRIPTION
There was a bug that if you had a field like this:

    {
      "field1": [0.0123, ...],
    }

viaq could not handle it properly and would omit it.  The fix
is to add support for both Hash and Array valued iterable fields.