### PR TITLE
do viaq processing/formatting in ruby code; create index names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,11 @@ rvm:
   - 2.3.1
 
 gemfile:
- - Gemfile
+  - Gemfile
+
+env:
+  - FLUENTD_VERSION=0.12.0
+  - FLUENTD_VERSION=0.14.0
 
 script: bundle exec rake test
 sudo: false

--- a/README.md
+++ b/README.md
@@ -70,6 +70,41 @@ See `filter-viaq_data_model.conf` for an example filter configuration.
 * `dest_time_name` - string - default `@timestamp`
   * This is the name of the top level field to hold the time value.  The value
   is taken from the value of the `src_time_name` field.
+* `formatter` - a formatter for a well known common data model source
+  * `type` - one of the well known sources
+    * `sys_journal` - a record read from the systemd journal
+    * `k8s_journal` - a Kubernetes container record read from the systemd
+      journal - should have `CONTAINER_NAME`, `CONTAINER_ID_FULL`
+    * `sys_var_log` - a record read from `/var/log/messages`
+    * `k8s_json_file` - a record read from a `/var/log/containers/*.log` JSON
+      formatted container log file
+    * `tag` - the Fluentd tag pattern to match for these records
+    * `remove_keys` - comma delimited list of keys to remove from the record
+* `pipeline_type` - which part of the pipeline is this? `collector` or
+  `normalizer` - the default is `collector`
+* `elasticsearch_index_name` - how to construct Elasticsearch index names for
+  given tags
+  * `tag` - the Fluentd tag pattern to match for these records
+  * `code` - a block of Ruby code to evaluate - this code will have access to a
+    variable called `record` which is the record matched by `tag` - the code
+    should evaluate to a `String` which will be the Elasticsearch index name
+    for this record.  The value will be stored in the record in the field named
+    by `elasticsearch_index_field`
+* `elasticsearch_index_field` - name of the field in the record which stores
+  the index name - you should remove this field in the elasticsearch output
+  plugin using the `remove_keys` config parameter
+
+**NOTE** The `formatter` blocks are matched in the given order in the file.
+  This means, don't use `tag "**"` as the first formatter or none of your
+  others will be matched or evaulated.
+
+**NOTE** The `elasticsearch_index_name` processing is done *last*, *after* the
+  formatting, removal of empty fields, `@timestamp` creation, etc., so use
+  e.g. `record['systemd']['t']['GID']` instead of `record['_GID']`
+
+**NOTE** The `elasticsearch_index_name` blocks are matched in the given order
+  in the file.  This means, don't use `tag "**"` as the first formatter or none
+  of your others will be matched or evaulated.
 
 ## Example
 
@@ -103,6 +138,95 @@ The resulting record, using the defaults, would look like this:
       "@timestamp": "2017-02-13 15:30:10.259106596-07:00"
     }
 
+## Formatter example
+
+Given a record like the following with a tag of `journal.system`
+
+    __REALTIME_TIMESTAMP=1502228121310282
+    __MONOTONIC_TIMESTAMP=722903835100
+    _BOOT_ID=d85e8a9d524c4a419bcfb6598db78524
+    _TRANSPORT=syslog
+    PRIORITY=6
+    SYSLOG_FACILITY=3
+    SYSLOG_IDENTIFIER=dnsmasq-dhcp
+    SYSLOG_PID=2289
+    _PID=2289
+    _UID=99
+    _GID=40
+    _COMM=dnsmasq
+    _EXE=/usr/sbin/dnsmasq
+    _CMDLINE=/sbin/dnsmasq --conf-file=/var/lib/libvirt/dnsmasq/default.conf --leasefile-ro --dhcp-script=/usr/libexec/libvirt_leaseshelper
+    _CAP_EFFECTIVE=3400
+    _SYSTEMD_CGROUP=/system.slice/libvirtd.service
+    MESSASGE=my message
+
+Using a configuration like this:
+
+    <formatter>
+      tag "journal.system**"
+      type sys_journal
+      remove_keys log,stream,MESSAGE,_SOURCE_REALTIME_TIMESTAMP,__REALTIME_TIMESTAMP,CONTAINER_ID,CONTAINER_ID_FULL,CONTAINER_NAME,PRIORITY,_BOOT_ID,_CAP_EFFECTIVE,_CMDLINE,_COMM,_EXE,_GID,_HOSTNAME,_MACHINE_ID,_PID,_SELINUX_CONTEXT,_SYSTEMD_CGROUP,_SYSTEMD_SLICE,_SYSTEMD_UNIT,_TRANSPORT,_UID,_AUDIT_LOGINUID,_AUDIT_SESSION,_SYSTEMD_OWNER_UID,_SYSTEMD_SESSION,_SYSTEMD_USER_UNIT,CODE_FILE,CODE_FUNCTION,CODE_LINE,ERRNO,MESSAGE_ID,RESULT,UNIT,_KERNEL_DEVICE,_KERNEL_SUBSYSTEM,_UDEV_SYSNAME,_UDEV_DEVNODE,_UDEV_DEVLINK,SYSLOG_FACILITY,SYSLOG_IDENTIFIER,SYSLOG_PID
+    </formatter>
+
+The resulting record will look like this:
+
+    {
+    "systemd": {
+      "t": {
+        "BOOT_ID":"d85e8a9d524c4a419bcfb6598db78524",
+        "GID":40,
+        ...
+      },
+      "u": {
+        "SYSLOG_FACILITY":3,
+        "SYSLOG_IDENTIFIER":"dnsmasq-dhcp",
+        ...
+      },
+    "message":"my message",
+    ...
+    }
+
+## Elasticsearch index name example
+
+Given a configuration like this:
+
+    <elasticsearch_index_name>
+      tag "journal.system** system.var.log** **_default_** **_openshift_** **_openshift-infra_** mux.ops"
+      code "begin \'.operations.\' + (record[\'@timestamp\'].nil? ? Time.at(time).getutc.strftime(\'%Y.%m.%d\') : Time.parse(record[\'@timestamp\']).getutc.strftime(\'%Y.%m.%d\')) rescue $log.error(\'record is missing time and @timestamp - record \' + record.to_s) end"
+    </elasticsearch_index_name>
+    <elasticsearch_index_name>
+      tag "**"
+      code "if record[\'kubernetes\'].nil?; $log.error(\'record is missing kubernetes field \' + record.to_s); elsif record[\'kubernetes\'][\'namespace_name\'].nil?; $log.error(\'record is missing kubernetes.namespace_name field \' + record.to_s); elsif record[\'kubernetes\'][\'namespace_id\'].nil?; $log.error(\'record is missing kubernetes.namespace_id field \' + record.to_s); elsif (record[\'@timestamp\'].nil? && record[\'time\'].nil?); $log.error(\'record is missing @timestamp and time fields \' + record.to_s); else \'project.\' + record[\'kubernetes\'][\'namespace_name\'] + \'.\' + record[\'kubernetes\'][\'namespace_id\'] + \'.\' + (record[\'@timestamp\'].nil? ? Time.at(time).getutc.strftime(\'%Y.%m.%d\') : Time.parse(record[\'@timestamp\']).getutc.strftime(\'%Y.%m.%d\')) end"
+    </elasticsearch_index_name>
+    elasticsearch_index_field viaq_index_name
+
+A record with tag `journal.system` like this:
+
+    {
+      "@timestamp":"2017-07-27T17:27:46.216527+00:00"
+    }
+
+will end up looking like this:
+
+    {
+      "@timestamp":"2017-07-27T17:27:46.216527+00:00",
+      "viaq_index_name":".operations.2017.07.07"
+    }
+
+A record with tag `kubernetes.journal.container` like this:
+
+    {
+      "@timestamp":"2017-07-27T17:27:46.216527+00:00",
+      "kubernetes":{"namespace_name":"myproject","namespace_uid":"000000"}
+    }
+
+will end up looking like this:
+
+    {
+      "@timestamp":"2017-07-27T17:27:46.216527+00:00",
+      "kubernetes":{"namespace_name":"myproject","namespace_uid":"000000"}
+      "viaq_index_name":"project.myproject.000000.2017.07.07"
+    }
 
 ## Installation
 

--- a/fluent-plugin-viaq_data_model.gemspec
+++ b/fluent-plugin-viaq_data_model.gemspec
@@ -2,9 +2,13 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
+# always build with latest fluentd, but allow
+# testing against earlier versions
+FLUENTD_VERSION = ENV['FLUENTD_VERSION'] || "0.14.0"
+
 Gem::Specification.new do |gem|
   gem.name          = "fluent-plugin-viaq_data_model"
-  gem.version       = "0.0.5"
+  gem.version       = "0.0.6"
   gem.authors       = ["Rich Megginson"]
   gem.email         = ["rmeggins@redhat.com"]
   gem.description   = %q{Filter plugin to ensure data is in the ViaQ common data model}
@@ -20,12 +24,13 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 2.0.0'
 
-  gem.add_runtime_dependency "fluentd", ">= 0.12.0"
+  gem.add_runtime_dependency "fluentd", "~> #{FLUENTD_VERSION}"
 
   gem.add_development_dependency "bundler"
-  gem.add_development_dependency("fluentd", ">= 0.12.0")
+  gem.add_development_dependency("fluentd", "~> #{FLUENTD_VERSION}")
   gem.add_development_dependency("rake", ["~> 11.0"])
   gem.add_development_dependency("rr", ["~> 1.0"])
   gem.add_development_dependency("test-unit", ["~> 3.2"])
   gem.add_development_dependency("test-unit-rr", ["~> 1.0"])
+  gem.add_development_dependency("flexmock", ["~> 2.0"])
 end

--- a/lib/fluent/plugin/filter_viaq_data_model.rb
+++ b/lib/fluent/plugin/filter_viaq_data_model.rb
@@ -15,8 +15,39 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+require 'time'
+require 'date'
+
 require 'fluent/filter'
 require 'fluent/log'
+require 'fluent/match'
+
+begin
+  ViaqMatchClass = Fluent::Match
+rescue
+  # Fluent::Match not provided with 0.14
+  class ViaqMatchClass
+    def initialize(pattern_str, unused)
+      patterns = pattern_str.split(/\s+/).map {|str|
+        Fluent::MatchPattern.create(str)
+      }
+      if patterns.length == 1
+        @pattern = patterns[0]
+      else
+        @pattern = Fluent::OrMatchPattern.new(patterns)
+      end
+    end
+    def match(tag)
+      if @pattern.match(tag)
+        return true
+      end
+      return false
+    end
+    def to_s
+      "#{@pattern}"
+    end
+  end
+end
 
 module Fluent
   class ViaqDataModelFilter < Filter
@@ -59,6 +90,37 @@ module Fluent
     desc 'Name of destination timestamp field'
     config_param :dest_time_name, :string, default: '@timestamp'
 
+    desc 'Process records matching this tag pattern as system journal records e.g. "journal.system** journal.container** journal"'
+    config_param :journal_system_record_tag, :string, default: nil
+
+    desc 'Process records matching this tag pattern as kubernetes journal records e.g. "kubernetes.journal.container**"'
+    config_param :journal_k8s_record_tag, :string, default: nil
+
+    desc 'Which part of the pipeline is this - collector, normalizer, etc.'
+    config_param :pipeline_type, :enum, list: [:collector, :normalizer], default: :collector
+
+    desc 'Fields to remove from the record - same as record_transformer "remove_keys" field'
+    config_param :remove_keys, :string, default: 'log,stream,MESSAGE,_SOURCE_REALTIME_TIMESTAMP,__REALTIME_TIMESTAMP,CONTAINER_ID,CONTAINER_ID_FULL,CONTAINER_NAME,PRIORITY,_BOOT_ID,_CAP_EFFECTIVE,_CMDLINE,_COMM,_EXE,_GID,_HOSTNAME,_MACHINE_ID,_PID,_SELINUX_CONTEXT,_SYSTEMD_CGROUP,_SYSTEMD_SLICE,_SYSTEMD_UNIT,_TRANSPORT,_UID,_AUDIT_LOGINUID,_AUDIT_SESSION,_SYSTEMD_OWNER_UID,_SYSTEMD_SESSION,_SYSTEMD_USER_UNIT,CODE_FILE,CODE_FUNCTION,CODE_LINE,ERRNO,MESSAGE_ID,RESULT,UNIT,_KERNEL_DEVICE,_KERNEL_SUBSYSTEM,_UDEV_SYSNAME,_UDEV_DEVNODE,_UDEV_DEVLINK,SYSLOG_FACILITY,SYSLOG_IDENTIFIER,SYSLOG_PID'
+
+    # e.g.
+    # <elasticsearch_index_name>
+    #   tag "journal.system** system.var.log** **_default_** **_openshift_** **_openshift-infra_** mux.ops"
+    #   code "begin '.operations.' + (record['@timestamp'].nil? ? Time.at(time).getutc.strftime('%Y.%m.%d') : Time.parse(record['@timestamp']).getutc.strftime('%Y.%m.%d')) rescue $log.error('record is missing time and @timestamp - record ' + record.to_s) end"
+    # </elasticsearch_index_name>
+    # <elasticsearch_index_name>
+    #   tag "**"
+    #   code "if record['kubernetes'].nil?; $log.error('record is missing kubernetes field ' + record.to_s); elsif record['kubernetes']['namespace_name'].nil?; $log.error('record is missing kubernetes.namespace_name field ' + record.to_s); elsif record['kubernetes']['namespace_id'].nil?; $log.error('record is missing kubernetes.namespace_id field ' + record.to_s); elsif (record['@timestamp'].nil? && record['time'].nil?); $log.error('record is missing @timestamp and time fields ' + record.to_s); else 'project.' + record['kubernetes']['namespace_name'] + '.' + record['kubernetes']['namespace_id'] + '.' + (record['@timestamp'].nil? ? Time.at(time).getutc.strftime('%Y.%m.%d') : Time.parse(record['@timestamp']).getutc.strftime('%Y.%m.%d')) end"
+    # </elasticsearch_index_name>
+    # the code will be wrapped as a method like this:
+    # def get_index_name(record) ... your code goes here ... end
+    # and the code must return a string
+    desc 'Construct Elasticsearch index names using given code based on the matching tags pattern'
+    config_section :elasticsearch_index_name, param_name: :elasticsearch_index_names do
+      config_param :tag, :string
+      config_param :code, :string
+    end
+    desc 'Store the Elasticsearch index name in this field'
+    config_param :elasticsearch_index_field, :string, default: nil
 
     def configure(conf)
       super
@@ -75,6 +137,46 @@ module Fluent
       end
       if (@rename_time || @rename_time_if_not_exist) && @use_undefined && !@keep_fields.key?(@src_time_name)
         raise Fluent::ConfigError, "Field [#{@src_time_name}] must be listed in default_keep_fields or extra_keep_fields"
+      end
+      if @journal_system_record_tag
+        @journal_system_record_match = ViaqMatchClass.new(@journal_system_record_tag, nil)
+      else
+        @journal_system_record_match = nil
+      end
+      if @journal_k8s_record_tag
+        @journal_k8s_record_match = ViaqMatchClass.new(@journal_k8s_record_tag, nil)
+      else
+        @journal_k8s_record_match = nil
+      end
+      begin
+        @docker_hostname = File.open('/etc/docker-hostname') { |f| f.readline }.rstrip
+      rescue
+        @docker_hostname = nil
+      end
+      @ipaddr4 = ENV['IPADDR4'] || '127.0.0.1'
+      @ipaddr6 = ENV['IPADDR6'] || '::1'
+      @pipeline_version = (ENV['FLUENTD_VERSION'] || 'unknown fluentd version') + ' ' + (ENV['DATA_VERSION'] || 'unknown data version')
+      if @remove_keys
+        @remove_keys_list = @remove_keys.split(',')
+      else
+        @remove_keys_list = nil
+      end
+      if @elasticsearch_index_field && @elasticsearch_index_names.empty?
+        raise Fluent::ConfigError, "Field elasticsearch_index_field specified but no elasticsearch_index_name values were configured"
+      end
+      if !@elasticsearch_index_names.empty? && !@elasticsearch_index_field
+        raise Fluent::ConfigError, "Field elasticsearch_index_name specified but no elasticsearch_index_field value was configured"
+      end
+      # compile the code
+      if !@elasticsearch_index_names.empty? && @elasticsearch_index_field
+        @elasticsearch_index_names.each do |ein|
+          func = eval('lambda{|record| ' + ein.code + '}')
+          ein.instance_eval{ @params[:func] = func }
+          matcher = ViaqMatchClass.new(ein.tag, nil)
+          ein.instance_eval{ @params[:matcher] = matcher }
+        end
+        # test the code
+        @elasticsearch_index_names.each{|ein| ein.func([])}
       end
     end
 
@@ -104,11 +206,150 @@ module Fluent
       thing
     end
 
+    # map of journal fields to viaq data model field
+    JOURNAL_FIELD_MAP_SYSTEMD_T = {
+      "_AUDIT_LOGINUID"    => "AUDIT_LOGINUID",
+      "_AUDIT_SESSION"     => "AUDIT_SESSION",
+      "_BOOT_ID"           => "BOOT_ID",
+      "_CAP_EFFECTIVE"     => "CAP_EFFECTIVE",
+      "_CMDLINE"           => "CMDLINE",
+      "_COMM"              => "COMM",
+      "_EXE"               => "EXE",
+      "_GID"               => "GID",
+      "_MACHINE_ID"        => "MACHINE_ID",
+      "_PID"               => "PID",
+      "_SELINUX_CONTEXT"   => "SELINUX_CONTEXT",
+      "_SYSTEMD_CGROUP"    => "SYSTEMD_CGROUP",
+      "_SYSTEMD_OWNER_UID" => "SYSTEMD_OWNER_UID",
+      "_SYSTEMD_SESSION"   => "SYSTEMD_SESSION",
+      "_SYSTEMD_SLICE"     => "SYSTEMD_SLICE",
+      "_SYSTEMD_UNIT"      => "SYSTEMD_UNIT",
+      "_SYSTEMD_USER_UNIT" => "SYSTEMD_USER_UNIT",
+      "_TRANSPORT"         => "TRANSPORT",
+      "_UID"               => "UID"
+    }
+
+    JOURNAL_FIELD_MAP_SYSTEMD_U = {
+      "CODE_FILE"         => "CODE_FILE",
+      "CODE_FUNCTION"     => "CODE_FUNCTION",
+      "CODE_LINE"         => "CODE_LINE",
+      "ERRNO"             => "ERRNO",
+      "MESSAGE_ID"        => "MESSAGE_ID",
+      "RESULT"            => "RESULT",
+      "UNIT"              => "UNIT",
+      "SYSLOG_FACILITY"   => "SYSLOG_FACILITY",
+      "SYSLOG_IDENTIFIER" => "SYSLOG_IDENTIFIER",
+      "SYSLOG_PID"        => "SYSLOG_PID"
+    }
+
+    JOURNAL_FIELD_MAP_SYSTEMD_K = {
+      "_KERNEL_DEVICE"    => "KERNEL_DEVICE",
+      "_KERNEL_SUBSYSTEM" => "KERNEL_SUBSYSTEM",
+      "_UDEV_SYSNAME"     => "UDEV_SYSNAME",
+      "_UDEV_DEVNODE"     => "UDEV_DEVNODE",
+      "_UDEV_DEVLINK"     => "UDEV_DEVLINK",
+    }
+
+    JOURNAL_TIME_FIELDS = ['_SOURCE_REALTIME_TIMESTAMP', '__REALTIME_TIMESTAMP']
+
+    def handle_journal_data(tag, time, record)
+      is_k8s_record = @journal_k8s_record_match && @journal_k8s_record_match.match(tag)
+      systemd_t = {}
+      JOURNAL_FIELD_MAP_SYSTEMD_T.each do |jkey, key|
+        if record[jkey]
+          systemd_t[key] = record[jkey]
+        end
+      end
+      systemd_u = {}
+      JOURNAL_FIELD_MAP_SYSTEMD_U.each do |jkey, key|
+        if record[jkey]
+          systemd_u[key] = record[jkey]
+        end
+      end
+      systemd_k = {}
+      JOURNAL_FIELD_MAP_SYSTEMD_K.each do |jkey, key|
+        if record[jkey]
+          systemd_k[key] = record[jkey]
+        end
+      end
+      unless systemd_t.empty?
+        (record['systemd'] ||= {})['t'] = systemd_t
+      end
+      unless systemd_u.empty?
+        (record['systemd'] ||= {})['u'] = systemd_u
+      end
+      unless systemd_k.empty?
+        (record['systemd'] ||= {})['k'] = systemd_k
+      end
+
+      if is_k8s_record
+        record['message'] = record['message'] || record['MESSAGE'] || record['log']
+      else
+        record['message'] = record['MESSAGE']
+      end
+
+      begin
+        pri_index = ('%d' % record['PRIORITY'] || 9).to_i
+        if pri_index < 0
+          pri_index = 9
+        end
+        if pri_index > 9
+          pri_index = 9
+        end
+      rescue
+        pri_index = 9
+      end
+      record['level'] = ["emerg", "alert", "crit", "err", "warning", "notice", "info", "debug", "trace", "unknown"][pri_index]
+
+      if is_k8s_record
+        if record['kubernetes'] && record['kubernetes']['host']
+          record['hostname'] = record['kubernetes']['host']
+        elsif @docker_hostname
+          record['hostname'] = @docker_hostname
+        else
+          record['hostname'] = record['_HOSTNAME']
+        end
+      else
+        if record['_HOSTNAME'].eql?('localhost') && @docker_hostname
+          record['hostname'] = @docker_hostname
+        else
+          record['hostname'] = record['_HOSTNAME']
+        end
+      end
+
+      JOURNAL_TIME_FIELDS.each do |field|
+        if record[field]
+          record['time'] = Time.at(record[field].to_f / 1000000.0).utc.to_datetime.rfc3339(6)
+          break
+        end
+      end
+
+      if record['time'].nil?
+        record['time'] = Time.at(time).utc.to_datetime.rfc3339(6)
+      end
+
+      (record['pipeline_metadata'] ||= {})[@pipeline_type.to_s] = {
+        "ipaddr4"     => @ipaddr4,
+        "ipaddr6"     => @ipaddr6,
+        "inputname"   => "fluent-plugin-systemd",
+        "name"        => "fluentd",
+        "received_at" => Time.at(time).utc.to_datetime.rfc3339(6),
+        "version"     => @pipeline_version
+      }
+
+      @remove_keys_list.each{|k| record.delete(k)} if @remove_keys_list
+    end
+
     def filter(tag, time, record)
       if ENV['CDM_DEBUG']
         unless tag == ENV['CDM_DEBUG_IGNORE_TAG']
           log.error("input #{time} #{tag} #{record}")
         end
+      end
+
+      if (@journal_system_record_match && @journal_system_record_match.match(tag)) ||
+         (@journal_k8s_record_match && @journal_k8s_record_match.match(tag))
+        handle_journal_data(tag, time, record)
       end
       if @use_undefined
         # undefined contains all of the fields not in keep_fields
@@ -130,6 +371,20 @@ module Fluent
         val = record.delete(@src_time_name)
         unless @rename_time_if_missing && record.key?(@dest_time_name)
           record[@dest_time_name] = val
+        end
+      end
+
+      if @elasticsearch_index_field && !@elasticsearch_index_names.empty?
+        found = false
+        @elasticsearch_index_names.each do |ein|
+          if ein.matcher.match(tag)
+            record[@elasticsearch_index_field] = ein.func.call(record)
+            found = true
+            break
+          end
+        end
+        unless found
+          log.warn("no match for tag #{tag}")
         end
       end
       if ENV['CDM_DEBUG']

--- a/test/test_filter_viaq_data_model.rb
+++ b/test/test_filter_viaq_data_model.rb
@@ -212,6 +212,440 @@ class ViaqDataModelFilterTest < Test::Unit::TestCase
       assert_equal([88], rec['h']['i']['m'])
       assert_true(rec['h']['i']['n'])
     end
+  end
 
+  sub_test_case 'journal' do
+    def emit_with_tag(tag, msg={}, conf='')
+      d = create_driver(conf)
+      d.run {
+        d.emit_with_tag(tag, msg, @time)
+      }.filtered.instance_variable_get(:@record_array)[0]
+    end
+
+    def setup
+      # elasticsearch index constructors use $log, so have to fake it
+      @orig_log = $log
+      $log = Fluent::Test::TestLogger.new
+    end
+
+    def teardown
+      $log = @orig_log
+    end
+
+    def normal_input
+      {
+        "_AUDIT_LOGINUID"            => "AUDIT_LOGINUID",
+        "_AUDIT_SESSION"             => "AUDIT_SESSION",
+        "_BOOT_ID"                   => "BOOT_ID",
+        "_CAP_EFFECTIVE"             => "CAP_EFFECTIVE",
+        "_CMDLINE"                   => "CMDLINE",
+        "_COMM"                      => "COMM",
+        "_EXE"                       => "EXE",
+        "_GID"                       => "GID",
+        "_MACHINE_ID"                => "MACHINE_ID",
+        "_PID"                       => "PID",
+        "_SELINUX_CONTEXT"           => "SELINUX_CONTEXT",
+        "_SYSTEMD_CGROUP"            => "SYSTEMD_CGROUP",
+        "_SYSTEMD_OWNER_UID"         => "SYSTEMD_OWNER_UID",
+        "_SYSTEMD_SESSION"           => "SYSTEMD_SESSION",
+        "_SYSTEMD_SLICE"             => "SYSTEMD_SLICE",
+        "_SYSTEMD_UNIT"              => "SYSTEMD_UNIT",
+        "_SYSTEMD_USER_UNIT"         => "SYSTEMD_USER_UNIT",
+        "_TRANSPORT"                 => "TRANSPORT",
+        "_UID"                       => "UID",
+        "CODE_FILE"                  => "CODE_FILE",
+        "CODE_FUNCTION"              => "CODE_FUNCTION",
+        "CODE_LINE"                  => "CODE_LINE",
+        "ERRNO"                      => "ERRNO",
+        "MESSAGE_ID"                 => "MESSAGE_ID",
+        "RESULT"                     => "RESULT",
+        "UNIT"                       => "UNIT",
+        "SYSLOG_FACILITY"            => "SYSLOG_FACILITY",
+        "SYSLOG_IDENTIFIER"          => "SYSLOG_IDENTIFIER",
+        "SYSLOG_PID"                 => "SYSLOG_PID",
+        "_KERNEL_DEVICE"             => "KERNEL_DEVICE",
+        "_KERNEL_SUBSYSTEM"          => "KERNEL_SUBSYSTEM",
+        "_UDEV_SYSNAME"              => "UDEV_SYSNAME",
+        "_UDEV_DEVNODE"              => "UDEV_DEVNODE",
+        "_UDEV_DEVLINK"              => "UDEV_DEVLINK",
+        "_SOURCE_REALTIME_TIMESTAMP" => "1501176466216527",
+        "__REALTIME_TIMESTAMP"       => "1501176466216527",
+        "MESSAGE"                    => "hello world",
+        "PRIORITY"                   => "6",
+        "_HOSTNAME"                  => "myhost"
+      }
+    end
+    def normal_output_t
+      {
+        "AUDIT_LOGINUID"    =>"AUDIT_LOGINUID",
+        "AUDIT_SESSION"     =>"AUDIT_SESSION",
+        "BOOT_ID"           =>"BOOT_ID",
+        "CAP_EFFECTIVE"     =>"CAP_EFFECTIVE",
+        "CMDLINE"           =>"CMDLINE",
+        "COMM"              =>"COMM",
+        "EXE"               =>"EXE",
+        "GID"               =>"GID",
+        "MACHINE_ID"        =>"MACHINE_ID",
+        "PID"               =>"PID",
+        "SELINUX_CONTEXT"   =>"SELINUX_CONTEXT",
+        "SYSTEMD_CGROUP"    =>"SYSTEMD_CGROUP",
+        "SYSTEMD_OWNER_UID" =>"SYSTEMD_OWNER_UID",
+        "SYSTEMD_SESSION"   =>"SYSTEMD_SESSION",
+        "SYSTEMD_SLICE"     =>"SYSTEMD_SLICE",
+        "SYSTEMD_UNIT"      =>"SYSTEMD_UNIT",
+        "SYSTEMD_USER_UNIT" =>"SYSTEMD_USER_UNIT",
+        "TRANSPORT"         =>"TRANSPORT",
+        "UID"               =>"UID"
+      }
+    end
+    def normal_output_u
+      {
+        "CODE_FILE"         =>"CODE_FILE",
+        "CODE_FUNCTION"     =>"CODE_FUNCTION",
+        "CODE_LINE"         =>"CODE_LINE",
+        "ERRNO"             =>"ERRNO",
+        "MESSAGE_ID"        =>"MESSAGE_ID",
+        "RESULT"            =>"RESULT",
+        "UNIT"              =>"UNIT",
+        "SYSLOG_FACILITY"   =>"SYSLOG_FACILITY",
+        "SYSLOG_IDENTIFIER" =>"SYSLOG_IDENTIFIER",
+        "SYSLOG_PID"        =>"SYSLOG_PID"
+      }
+    end
+    def normal_output_k
+      {
+        "KERNEL_DEVICE"    =>"KERNEL_DEVICE",
+        "KERNEL_SUBSYSTEM" =>"KERNEL_SUBSYSTEM",
+        "UDEV_SYSNAME"     =>"UDEV_SYSNAME",
+        "UDEV_DEVNODE"     =>"UDEV_DEVNODE",
+        "UDEV_DEVLINK"     =>"UDEV_DEVLINK"
+      }
+    end
+    test 'match records with journal_system_record_tag' do
+      rec = emit_with_tag('journal.system', {'a'=>'b', 'MESSAGE'=>'here'}, '
+        journal_system_record_tag "journal.system**"
+      ')
+      assert_equal('b', rec['a'])
+      assert_equal('here', rec['message'])
+    end
+    test 'do not match records without journal_system_record_tag' do
+      rec = emit_with_tag('journal.systm', {'a'=>'b', 'MESSAGE'=>'here'}, '
+        journal_system_record_tag "journal.system**"
+      ')
+      assert_equal('b', rec['a'])
+      assert_equal('here', rec['MESSAGE'])
+    end
+    test 'process a journal record, default settings' do
+      ENV['IPADDR4'] = '127.0.0.1'
+      ENV['IPADDR6'] = '::1'
+      ENV['FLUENTD_VERSION'] = 'fversion'
+      ENV['DATA_VERSION'] = 'dversion'
+      rec = emit_with_tag('journal.system', normal_input, '
+        journal_system_record_tag "journal.system**"
+        pipeline_type normalizer
+      ')
+      assert_equal(rec['systemd']['t'], normal_output_t)
+      assert_equal(rec['systemd']['u'], normal_output_u)
+      assert_equal(rec['systemd']['k'], normal_output_k)
+      assert_equal(rec['message'], 'hello world')
+      assert_equal(rec['level'], 'info')
+      assert_equal(rec['hostname'], 'myhost')
+      assert_equal(rec['@timestamp'], '2017-07-27T17:27:46.216527+00:00')
+      assert_equal(rec['pipeline_metadata']['normalizer']['ipaddr4'], '127.0.0.1')
+      assert_equal(rec['pipeline_metadata']['normalizer']['ipaddr6'], '::1')
+      assert_equal(rec['pipeline_metadata']['normalizer']['inputname'], 'fluent-plugin-systemd')
+      assert_equal(rec['pipeline_metadata']['normalizer']['name'], 'fluentd')
+      assert_equal(rec['pipeline_metadata']['normalizer']['version'], 'fversion dversion')
+      assert_equal(rec['pipeline_metadata']['normalizer']['received_at'], Time.at(@time).utc.to_datetime.rfc3339(6))
+      dellist = 'log,stream,MESSAGE,_SOURCE_REALTIME_TIMESTAMP,__REALTIME_TIMESTAMP,CONTAINER_ID,CONTAINER_ID_FULL,CONTAINER_NAME,PRIORITY,_BOOT_ID,_CAP_EFFECTIVE,_CMDLINE,_COMM,_EXE,_GID,_HOSTNAME,_MACHINE_ID,_PID,_SELINUX_CONTEXT,_SYSTEMD_CGROUP,_SYSTEMD_SLICE,_SYSTEMD_UNIT,_TRANSPORT,_UID,_AUDIT_LOGINUID,_AUDIT_SESSION,_SYSTEMD_OWNER_UID,_SYSTEMD_SESSION,_SYSTEMD_USER_UNIT,CODE_FILE,CODE_FUNCTION,CODE_LINE,ERRNO,MESSAGE_ID,RESULT,UNIT,_KERNEL_DEVICE,_KERNEL_SUBSYSTEM,_UDEV_SYSNAME,_UDEV_DEVNODE,_UDEV_DEVLINK,SYSLOG_FACILITY,SYSLOG_IDENTIFIER,SYSLOG_PID'.split(',')
+      dellist.each{|field| assert_nil(rec[field])}
+    end
+    test 'process a journal record, override remove_keys' do
+      ENV['IPADDR4'] = '127.0.0.1'
+      ENV['IPADDR6'] = '::1'
+      ENV['FLUENTD_VERSION'] = 'fversion'
+      ENV['DATA_VERSION'] = 'dversion'
+      rec = emit_with_tag('journal.system', normal_input, '
+        journal_system_record_tag "journal.system**"
+        pipeline_type normalizer
+        remove_keys CONTAINER_NAME,PRIORITY
+      ')
+      assert_equal(rec['systemd']['t'], normal_output_t)
+      assert_equal(rec['systemd']['u'], normal_output_u)
+      assert_equal(rec['systemd']['k'], normal_output_k)
+      assert_equal(rec['message'], 'hello world')
+      assert_equal(rec['level'], 'info')
+      assert_equal(rec['hostname'], 'myhost')
+      assert_equal(rec['@timestamp'], '2017-07-27T17:27:46.216527+00:00')
+      assert_equal(rec['pipeline_metadata']['normalizer']['ipaddr4'], '127.0.0.1')
+      assert_equal(rec['pipeline_metadata']['normalizer']['ipaddr6'], '::1')
+      assert_equal(rec['pipeline_metadata']['normalizer']['inputname'], 'fluent-plugin-systemd')
+      assert_equal(rec['pipeline_metadata']['normalizer']['name'], 'fluentd')
+      assert_equal(rec['pipeline_metadata']['normalizer']['version'], 'fversion dversion')
+      assert_equal(rec['pipeline_metadata']['normalizer']['received_at'], Time.at(@time).utc.to_datetime.rfc3339(6))
+      keeplist = 'log,stream,MESSAGE,_SOURCE_REALTIME_TIMESTAMP,__REALTIME_TIMESTAMP,CONTAINER_ID,CONTAINER_ID_FULL,_BOOT_ID,_CAP_EFFECTIVE,_CMDLINE,_COMM,_EXE,_GID,_HOSTNAME,_MACHINE_ID,_PID,_SELINUX_CONTEXT,_SYSTEMD_CGROUP,_SYSTEMD_SLICE,_SYSTEMD_UNIT,_TRANSPORT,_UID,_AUDIT_LOGINUID,_AUDIT_SESSION,_SYSTEMD_OWNER_UID,_SYSTEMD_SESSION,_SYSTEMD_USER_UNIT,CODE_FILE,CODE_FUNCTION,CODE_LINE,ERRNO,MESSAGE_ID,RESULT,UNIT,_KERNEL_DEVICE,_KERNEL_SUBSYSTEM,_UDEV_SYSNAME,_UDEV_DEVNODE,_UDEV_DEVLINK,SYSLOG_FACILITY,SYSLOG_IDENTIFIER,SYSLOG_PID'.split(',')
+      keeplist.each{|field| normal_input[field] && assert_not_nil(rec[field])}
+      dellist = 'CONTAINER_NAME,PRIORITY'.split(',')
+      dellist.each{|field| assert_nil(rec[field])}
+    end
+    test 'try a PRIORITY value that is too large' do
+      rec = emit_with_tag('journal.system', {'a'=>'b', 'PRIORITY'=>'10'}, '
+        journal_system_record_tag "journal.system**"
+      ')
+      assert_equal('b', rec['a'])
+      assert_equal('unknown', rec['level'])
+    end
+    test 'try a PRIORITY value that is too small' do
+      rec = emit_with_tag('journal.system', {'a'=>'b', 'PRIORITY'=>'-1'}, '
+        journal_system_record_tag "journal.system**"
+      ')
+      assert_equal('b', rec['a'])
+      assert_equal('unknown', rec['level'])
+    end
+    test 'try a PRIORITY value that is not a number' do
+      rec = emit_with_tag('journal.system', {'a'=>'b', 'PRIORITY'=>'NaN'}, '
+        journal_system_record_tag "journal.system**"
+      ')
+      assert_equal('b', rec['a'])
+      assert_equal('unknown', rec['level'])
+    end
+    test 'try a PRIORITY value that is a floating point number' do
+      rec = emit_with_tag('journal.system', {'a'=>'b', 'PRIORITY'=>'1.0'}, '
+        journal_system_record_tag "journal.system**"
+      ')
+      assert_equal('b', rec['a'])
+      assert_equal('unknown', rec['level'])
+    end
+    test 'test with fallback to __REALTIME_TIMESTAMP' do
+      input = normal_input.reject{|k,v| k == '_SOURCE_REALTIME_TIMESTAMP'}
+      rec = emit_with_tag('journal.system', input, '
+        journal_system_record_tag "journal.system**"
+      ')
+      assert_equal(rec['@timestamp'], '2017-07-27T17:27:46.216527+00:00')
+    end
+    test 'test using internal time if no timestamp given' do
+      input = normal_input.reject do |k,v|
+        k == '_SOURCE_REALTIME_TIMESTAMP' || k == '__REALTIME_TIMESTAMP'
+      end
+      rec = emit_with_tag('journal.system', input, '
+        journal_system_record_tag "journal.system**"
+      ')
+      assert_equal(rec['@timestamp'], Time.at(@time).utc.to_datetime.rfc3339(6))
+    end
+    test 'process a kubernetes journal record, default settings' do
+      ENV['IPADDR4'] = '127.0.0.1'
+      ENV['IPADDR6'] = '::1'
+      ENV['FLUENTD_VERSION'] = 'fversion'
+      ENV['DATA_VERSION'] = 'dversion'
+      rec = emit_with_tag('kubernetes.journal.container', normal_input, '
+        journal_k8s_record_tag "kubernetes.journal.container**"
+        pipeline_type normalizer
+      ')
+      assert_equal(rec['systemd']['t'], normal_output_t)
+      assert_equal(rec['systemd']['u'], normal_output_u)
+      assert_equal(rec['systemd']['k'], normal_output_k)
+      assert_equal(rec['message'], 'hello world')
+      assert_equal(rec['level'], 'info')
+      assert_equal(rec['hostname'], 'myhost')
+      assert_equal(rec['@timestamp'], '2017-07-27T17:27:46.216527+00:00')
+      assert_equal(rec['pipeline_metadata']['normalizer']['ipaddr4'], '127.0.0.1')
+      assert_equal(rec['pipeline_metadata']['normalizer']['ipaddr6'], '::1')
+      assert_equal(rec['pipeline_metadata']['normalizer']['inputname'], 'fluent-plugin-systemd')
+      assert_equal(rec['pipeline_metadata']['normalizer']['name'], 'fluentd')
+      assert_equal(rec['pipeline_metadata']['normalizer']['version'], 'fversion dversion')
+      assert_equal(rec['pipeline_metadata']['normalizer']['received_at'], Time.at(@time).utc.to_datetime.rfc3339(6))
+      dellist = 'log,stream,MESSAGE,_SOURCE_REALTIME_TIMESTAMP,__REALTIME_TIMESTAMP,CONTAINER_ID,CONTAINER_ID_FULL,CONTAINER_NAME,PRIORITY,_BOOT_ID,_CAP_EFFECTIVE,_CMDLINE,_COMM,_EXE,_GID,_HOSTNAME,_MACHINE_ID,_PID,_SELINUX_CONTEXT,_SYSTEMD_CGROUP,_SYSTEMD_SLICE,_SYSTEMD_UNIT,_TRANSPORT,_UID,_AUDIT_LOGINUID,_AUDIT_SESSION,_SYSTEMD_OWNER_UID,_SYSTEMD_SESSION,_SYSTEMD_USER_UNIT,CODE_FILE,CODE_FUNCTION,CODE_LINE,ERRNO,MESSAGE_ID,RESULT,UNIT,_KERNEL_DEVICE,_KERNEL_SUBSYSTEM,_UDEV_SYSNAME,_UDEV_DEVNODE,_UDEV_DEVLINK,SYSLOG_FACILITY,SYSLOG_IDENTIFIER,SYSLOG_PID'.split(',')
+      dellist.each{|field| assert_nil(rec[field])}
+    end
+    test 'process a kubernetes journal record, given kubernetes.host' do
+      input = normal_input.merge({})
+      input['kubernetes'] = {'host' => 'k8shost'}
+      ENV['IPADDR4'] = '127.0.0.1'
+      ENV['IPADDR6'] = '::1'
+      ENV['FLUENTD_VERSION'] = 'fversion'
+      ENV['DATA_VERSION'] = 'dversion'
+      rec = emit_with_tag('kubernetes.journal.container', input, '
+        journal_k8s_record_tag "kubernetes.journal.container**"
+        pipeline_type normalizer
+      ')
+      assert_equal(rec['systemd']['t'], normal_output_t)
+      assert_equal(rec['systemd']['u'], normal_output_u)
+      assert_equal(rec['systemd']['k'], normal_output_k)
+      assert_equal(rec['message'], 'hello world')
+      assert_equal(rec['level'], 'info')
+      assert_equal(rec['hostname'], 'k8shost')
+      assert_equal(rec['@timestamp'], '2017-07-27T17:27:46.216527+00:00')
+      assert_equal(rec['pipeline_metadata']['normalizer']['ipaddr4'], '127.0.0.1')
+      assert_equal(rec['pipeline_metadata']['normalizer']['ipaddr6'], '::1')
+      assert_equal(rec['pipeline_metadata']['normalizer']['inputname'], 'fluent-plugin-systemd')
+      assert_equal(rec['pipeline_metadata']['normalizer']['name'], 'fluentd')
+      assert_equal(rec['pipeline_metadata']['normalizer']['version'], 'fversion dversion')
+      assert_equal(rec['pipeline_metadata']['normalizer']['received_at'], Time.at(@time).utc.to_datetime.rfc3339(6))
+      dellist = 'log,stream,MESSAGE,_SOURCE_REALTIME_TIMESTAMP,__REALTIME_TIMESTAMP,CONTAINER_ID,CONTAINER_ID_FULL,CONTAINER_NAME,PRIORITY,_BOOT_ID,_CAP_EFFECTIVE,_CMDLINE,_COMM,_EXE,_GID,_HOSTNAME,_MACHINE_ID,_PID,_SELINUX_CONTEXT,_SYSTEMD_CGROUP,_SYSTEMD_SLICE,_SYSTEMD_UNIT,_TRANSPORT,_UID,_AUDIT_LOGINUID,_AUDIT_SESSION,_SYSTEMD_OWNER_UID,_SYSTEMD_SESSION,_SYSTEMD_USER_UNIT,CODE_FILE,CODE_FUNCTION,CODE_LINE,ERRNO,MESSAGE_ID,RESULT,UNIT,_KERNEL_DEVICE,_KERNEL_SUBSYSTEM,_UDEV_SYSNAME,_UDEV_DEVNODE,_UDEV_DEVLINK,SYSLOG_FACILITY,SYSLOG_IDENTIFIER,SYSLOG_PID'.split(',')
+      dellist.each{|field| assert_nil(rec[field])}
+    end
+    test 'process a kubernetes journal record, preserve message field' do
+      input = normal_input.merge({})
+      input['message'] = 'my message'
+      ENV['IPADDR4'] = '127.0.0.1'
+      ENV['IPADDR6'] = '::1'
+      ENV['FLUENTD_VERSION'] = 'fversion'
+      ENV['DATA_VERSION'] = 'dversion'
+      rec = emit_with_tag('kubernetes.journal.container', input, '
+        journal_k8s_record_tag "kubernetes.journal.container**"
+        pipeline_type normalizer
+      ')
+      assert_equal(rec['systemd']['t'], normal_output_t)
+      assert_equal(rec['systemd']['u'], normal_output_u)
+      assert_equal(rec['systemd']['k'], normal_output_k)
+      assert_equal(rec['message'], 'my message')
+      assert_equal(rec['level'], 'info')
+      assert_equal(rec['hostname'], 'myhost')
+      assert_equal(rec['@timestamp'], '2017-07-27T17:27:46.216527+00:00')
+      assert_equal(rec['pipeline_metadata']['normalizer']['ipaddr4'], '127.0.0.1')
+      assert_equal(rec['pipeline_metadata']['normalizer']['ipaddr6'], '::1')
+      assert_equal(rec['pipeline_metadata']['normalizer']['inputname'], 'fluent-plugin-systemd')
+      assert_equal(rec['pipeline_metadata']['normalizer']['name'], 'fluentd')
+      assert_equal(rec['pipeline_metadata']['normalizer']['version'], 'fversion dversion')
+      assert_equal(rec['pipeline_metadata']['normalizer']['received_at'], Time.at(@time).utc.to_datetime.rfc3339(6))
+      dellist = 'log,stream,MESSAGE,_SOURCE_REALTIME_TIMESTAMP,__REALTIME_TIMESTAMP,CONTAINER_ID,CONTAINER_ID_FULL,CONTAINER_NAME,PRIORITY,_BOOT_ID,_CAP_EFFECTIVE,_CMDLINE,_COMM,_EXE,_GID,_HOSTNAME,_MACHINE_ID,_PID,_SELINUX_CONTEXT,_SYSTEMD_CGROUP,_SYSTEMD_SLICE,_SYSTEMD_UNIT,_TRANSPORT,_UID,_AUDIT_LOGINUID,_AUDIT_SESSION,_SYSTEMD_OWNER_UID,_SYSTEMD_SESSION,_SYSTEMD_USER_UNIT,CODE_FILE,CODE_FUNCTION,CODE_LINE,ERRNO,MESSAGE_ID,RESULT,UNIT,_KERNEL_DEVICE,_KERNEL_SUBSYSTEM,_UDEV_SYSNAME,_UDEV_DEVNODE,_UDEV_DEVLINK,SYSLOG_FACILITY,SYSLOG_IDENTIFIER,SYSLOG_PID'.split(',')
+      dellist.each{|field| assert_nil(rec[field])}
+    end
+    test 'expect error from elasticsearch_index_field but no elasticsearch_index_names' do
+      assert_raise(Fluent::ConfigError) {
+        rec = emit_with_tag('journal.system', normal_input, '
+            elasticsearch_index_field viaq_index_name
+        ')
+      }
+    end
+    test 'expect error from elasticsearch_index_names but no elasticsearch_index_field' do
+      assert_raise(Fluent::ConfigError) {
+        rec = emit_with_tag('journal.system', normal_input, '
+            <elasticsearch_index_name>
+              tag "junk"
+              code "\'word\'"
+            </elasticsearch_index_name>
+        ')
+      }
+    end
+    test 'expect error from missing elasticsearch_index_names code' do
+      assert_raise(Fluent::ConfigError) {
+        rec = emit_with_tag('journal.system', normal_input, '
+            <elasticsearch_index_name>
+              tag "junk"
+            </elasticsearch_index_name>
+            elasticsearch_index_field junk
+        ')
+      }
+    end
+    test 'expect error from missing elasticsearch_index_names tag' do
+      assert_raise(Fluent::ConfigError) {
+        rec = emit_with_tag('journal.system', normal_input, '
+            <elasticsearch_index_name>
+              code "junk"
+            </elasticsearch_index_name>
+            elasticsearch_index_field junk
+        ')
+      }
+    end
+    test 'construct an operations index name' do
+      rec = emit_with_tag('journal.system', normal_input, '
+        journal_system_record_tag "journal.system**"
+        journal_k8s_record_tag "kubernetes.journal.container**"
+        <elasticsearch_index_name>
+          tag "journal.system** system.var.log** **_default_** **_openshift_** **_openshift-infra_** mux.ops"
+          code "begin \'.operations.\' + (record[\'@timestamp\'].nil? ? Time.at(time).getutc.strftime(\'%Y.%m.%d\') : Time.parse(record[\'@timestamp\']).getutc.strftime(\'%Y.%m.%d\')) rescue $log.error(\'record is missing time and @timestamp - record \' + record.to_s) end"
+        </elasticsearch_index_name>
+        <elasticsearch_index_name>
+          tag "**"
+          code "if record[\'kubernetes\'].nil?; $log.error(\'record is missing kubernetes field \' + record.to_s); elsif record[\'kubernetes\'][\'namespace_name\'].nil?; $log.error(\'record is missing kubernetes.namespace_name field \' + record.to_s); elsif record[\'kubernetes\'][\'namespace_id\'].nil?; $log.error(\'record is missing kubernetes.namespace_id field \' + record.to_s); elsif (record[\'@timestamp\'].nil? || record[\'time\'].nil?); $log.error(\'record is missing @timestamp and time fields \' + record.to_s); else \'project.\' + record[\'kubernetes\'][\'namespace_name\'] + \'.\' + record[\'kubernetes\'][\'namespace_id\'] + \'.\' + (record[\'@timestamp\'].nil? ? Time.at(time).getutc.strftime(\'%Y.%m.%d\') : Time.parse(record[\'@timestamp\']).getutc.strftime(\'%Y.%m.%d\')) end"
+        </elasticsearch_index_name>
+        elasticsearch_index_field viaq_index_name
+      ')
+      assert_equal(rec['viaq_index_name'], '.operations.2017.07.27')
+    end
+    test 'log error if missing kubernetes field' do
+      # elasticsearch index constructors use $log, so have to fake it
+      orig_log = $log
+      $log = Fluent::Test::TestLogger.new
+      rec = emit_with_tag('kubernetes.journal.container.something', normal_input, '
+        journal_system_record_tag "journal.system**"
+        journal_k8s_record_tag "kubernetes.journal.container**"
+        <elasticsearch_index_name>
+          tag "journal.system** system.var.log** **_default_** **_openshift_** **_openshift-infra_** mux.ops"
+          code "begin \'.operations.\' + (record[\'@timestamp\'].nil? ? Time.at(time).getutc.strftime(\'%Y.%m.%d\') : Time.parse(record[\'@timestamp\']).getutc.strftime(\'%Y.%m.%d\')) rescue $log.error(\'record is missing time and @timestamp - record \' + record.to_s) end"
+        </elasticsearch_index_name>
+        <elasticsearch_index_name>
+          tag "**"
+          code "if record[\'kubernetes\'].nil?; $log.error(\'record is missing kubernetes field \' + record.to_s); elsif record[\'kubernetes\'][\'namespace_name\'].nil?; $log.error(\'record is missing kubernetes.namespace_name field \' + record.to_s); elsif record[\'kubernetes\'][\'namespace_id\'].nil?; $log.error(\'record is missing kubernetes.namespace_id field \' + record.to_s); elsif (record[\'@timestamp\'].nil? || record[\'time\'].nil?); $log.error(\'record is missing @timestamp and time fields \' + record.to_s); else \'project.\' + record[\'kubernetes\'][\'namespace_name\'] + \'.\' + record[\'kubernetes\'][\'namespace_id\'] + \'.\' + (record[\'@timestamp\'].nil? ? Time.at(time).getutc.strftime(\'%Y.%m.%d\') : Time.parse(record[\'@timestamp\']).getutc.strftime(\'%Y.%m.%d\')) end"
+        </elasticsearch_index_name>
+        elasticsearch_index_field viaq_index_name
+      ')
+      assert_match /record is missing kubernetes field/, $log.logs[0]
+      $log = orig_log
+    end
+    test 'log error if missing kubernetes.namespace_name field' do
+      # elasticsearch index constructors use $log, so have to fake it
+      orig_log = $log
+      $log = Fluent::Test::TestLogger.new
+      input = normal_input.merge({})
+      input['kubernetes'] = 'junk'
+      rec = emit_with_tag('kubernetes.journal.container.something', input, '
+        journal_system_record_tag "journal.system**"
+        journal_k8s_record_tag "kubernetes.journal.container**"
+        <elasticsearch_index_name>
+          tag "journal.system** system.var.log** **_default_** **_openshift_** **_openshift-infra_** mux.ops"
+          code "begin \'.operations.\' + (record[\'@timestamp\'].nil? ? Time.at(time).getutc.strftime(\'%Y.%m.%d\') : Time.parse(record[\'@timestamp\']).getutc.strftime(\'%Y.%m.%d\')) rescue $log.error(\'record is missing time and @timestamp - record \' + record.to_s) end"
+        </elasticsearch_index_name>
+        <elasticsearch_index_name>
+          tag "**"
+          code "if record[\'kubernetes\'].nil?; $log.error(\'record is missing kubernetes field \' + record.to_s); elsif record[\'kubernetes\'][\'namespace_name\'].nil?; $log.error(\'record is missing kubernetes.namespace_name field \' + record.to_s); elsif record[\'kubernetes\'][\'namespace_id\'].nil?; $log.error(\'record is missing kubernetes.namespace_id field \' + record.to_s); elsif (record[\'@timestamp\'].nil? || record[\'time\'].nil?); $log.error(\'record is missing @timestamp and time fields \' + record.to_s); else \'project.\' + record[\'kubernetes\'][\'namespace_name\'] + \'.\' + record[\'kubernetes\'][\'namespace_id\'] + \'.\' + (record[\'@timestamp\'].nil? ? Time.at(time).getutc.strftime(\'%Y.%m.%d\') : Time.parse(record[\'@timestamp\']).getutc.strftime(\'%Y.%m.%d\')) end"
+        </elasticsearch_index_name>
+        elasticsearch_index_field viaq_index_name
+      ')
+      assert_match /record is missing kubernetes.namespace_name field/, $log.logs[0]
+      $log = orig_log
+    end
+    test 'log error if missing kubernetes.namespace_id field' do
+      # elasticsearch index constructors use $log, so have to fake it
+      orig_log = $log
+      $log = Fluent::Test::TestLogger.new
+      input = normal_input.merge({})
+      input['kubernetes'] = {'namespace_name'=>'junk'}
+      rec = emit_with_tag('kubernetes.journal.container.something', input, '
+        journal_system_record_tag "journal.system**"
+        journal_k8s_record_tag "kubernetes.journal.container**"
+        <elasticsearch_index_name>
+          tag "journal.system** system.var.log** **_default_** **_openshift_** **_openshift-infra_** mux.ops"
+          code "begin \'.operations.\' + (record[\'@timestamp\'].nil? ? Time.at(time).getutc.strftime(\'%Y.%m.%d\') : Time.parse(record[\'@timestamp\']).getutc.strftime(\'%Y.%m.%d\')) rescue $log.error(\'record is missing time and @timestamp - record \' + record.to_s) end"
+        </elasticsearch_index_name>
+        <elasticsearch_index_name>
+          tag "**"
+          code "if record[\'kubernetes\'].nil?; $log.error(\'record is missing kubernetes field \' + record.to_s); elsif record[\'kubernetes\'][\'namespace_name\'].nil?; $log.error(\'record is missing kubernetes.namespace_name field \' + record.to_s); elsif record[\'kubernetes\'][\'namespace_id\'].nil?; $log.error(\'record is missing kubernetes.namespace_id field \' + record.to_s); elsif (record[\'@timestamp\'].nil? || record[\'time\'].nil?); $log.error(\'record is missing @timestamp and time fields \' + record.to_s); else \'project.\' + record[\'kubernetes\'][\'namespace_name\'] + \'.\' + record[\'kubernetes\'][\'namespace_id\'] + \'.\' + (record[\'@timestamp\'].nil? ? Time.at(time).getutc.strftime(\'%Y.%m.%d\') : Time.parse(record[\'@timestamp\']).getutc.strftime(\'%Y.%m.%d\')) end"
+        </elasticsearch_index_name>
+        elasticsearch_index_field viaq_index_name
+      ')
+      assert_match /record is missing kubernetes.namespace_id field/, $log.logs[0]
+      $log = orig_log
+    end
+    test 'construct a kubernetes index name field' do
+      # elasticsearch index constructors use $log, so have to fake it
+      input = normal_input.merge({})
+      input['kubernetes'] = {'namespace_name'=>'name', 'namespace_id'=>'uuid'}
+      rec = emit_with_tag('kubernetes.journal.container.something', input, '
+        journal_system_record_tag "journal.system**"
+        journal_k8s_record_tag "kubernetes.journal.container**"
+        <elasticsearch_index_name>
+          tag "journal.system** system.var.log** **_default_** **_openshift_** **_openshift-infra_** mux.ops"
+          code "begin \'.operations.\' + (record[\'@timestamp\'].nil? ? Time.at(time).getutc.strftime(\'%Y.%m.%d\') : Time.parse(record[\'@timestamp\']).getutc.strftime(\'%Y.%m.%d\')) rescue $log.error(\'record is missing time and @timestamp - record \' + record.to_s) end"
+        </elasticsearch_index_name>
+        <elasticsearch_index_name>
+          tag "**"
+          code "if record[\'kubernetes\'].nil?; $log.error(\'record is missing kubernetes field \' + record.to_s); elsif record[\'kubernetes\'][\'namespace_name\'].nil?; $log.error(\'record is missing kubernetes.namespace_name field \' + record.to_s); elsif record[\'kubernetes\'][\'namespace_id\'].nil?; $log.error(\'record is missing kubernetes.namespace_id field \' + record.to_s); elsif (record[\'@timestamp\'].nil? && record[\'time\'].nil?); $log.error(\'record is missing @timestamp and time fields \' + record.to_s); else \'project.\' + record[\'kubernetes\'][\'namespace_name\'] + \'.\' + record[\'kubernetes\'][\'namespace_id\'] + \'.\' + (record[\'@timestamp\'].nil? ? Time.at(time).getutc.strftime(\'%Y.%m.%d\') : Time.parse(record[\'@timestamp\']).getutc.strftime(\'%Y.%m.%d\')) end"
+        </elasticsearch_index_name>
+        elasticsearch_index_field viaq_index_name
+      ')
+      assert_equal(rec['viaq_index_name'], 'project.name.uuid.2017.07.27')
+    end
   end
 end


### PR DESCRIPTION
This allows the viaq filter to be used to convert systemd journal
records read in by the systemd journal input.  This also allows
the viaq filter to construct Elasticsearch index names for
openshift/origin-aggregated-logging for the operations and
kubernetes indices.
`journal_system_record_tag` - tag pattern used to match
system logs read from the journal e.g.

    journal_system_record_tag "journal.system** journal.container** journal"

`journal_k8s_record_tag` - tag pattern used to match
kubernetes logs read from the journal e.g.

    journal_k8s_record_tag "kubernetes.journal.container**"

`pipeline_type` - pipeline type to be added to the
`pipeline_metadata` field, either `collector` or `normalizer`.  The
default value is `collector`.

`remove_keys` - This is the comma delimited list of fields to remove
from the record when processing the systemd journal log records.

`elasticsearch_index_name` - section which describes how to construct
the Elasticsearch index name based on the given tag pattern

* `tag` - tag pattern to match e.g. "journal.system** system.var.log**"
* `code` - this is a string of valid Ruby code which must return a
           string which will be used as the value of the index name

`elasticsearch_index_field` - name of field to insert into the record
containing the index name.  This will be used by the
`fluent-plugin-elasticsearch` by the `target_index_name` configuration.

Example:

    elasticsearch_index_field viaq_index_name
    <elasticsearch_index_name>
      tag "journal.system** system.var.log** **_default_** **_openshift_** **_openshift-infra_** mux.ops"
      code "begin '.operations.' + (record['@timestamp'].nil? ? Time.at(time).getutc.strftime('%Y.%m.%d') : Time.parse(record['@timestamp']).getutc.strftime('%Y.%m.%d')) rescue $log.error('record is missing time and @timestamp - record ' + record.to_s) end"
    </elasticsearch_index_name>
    <elasticsearch_index_name>
      tag "**"
      code "if record['kubernetes'].nil?; $log.error('record is missing kubernetes field ' + record.to_s); elsif record['kubernetes']['namespace_name'].nil?; $log.error('record is missing kubernetes.namespace_name field ' + record.to_s); elsif record['kubernetes']['namespace_id'].nil?; $log.error('record is missing kubernetes.namespace_id field ' + record.to_s); elsif (record['@timestamp'].nil? && record['time'].nil?); $log.error('record is missing @timestamp and time fields ' + record.to_s); else 'project.' + record['kubernetes']['namespace_name'] + '.' + record['kubernetes']['namespace_id'] + '.' + (record['@timestamp'].nil? ? Time.at(time).getutc.strftime('%Y.%m.%d') : Time.parse(record['@timestamp']).getutc.strftime('%Y.%m.%d')) end"
    </elasticsearch_index_name>

The tags are matched in the order given, so don't put `tag "**"` first or
no other tags will ever match.  The above will first find a match using
various tag patterns for an operations index, then will fallback and match
everything else to construct a kubernetes index name.