### PR TITLE
do viaq processing/formatting in ruby code; create index names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,11 @@ rvm:
   - 2.3.1
 
 gemfile:
- - Gemfile
+  - Gemfile
+
+env:
+  - FLUENTD_VERSION=0.12.0
+  - FLUENTD_VERSION=0.14.0
 
 script: bundle exec rake test
 sudo: false

--- a/README.md
+++ b/README.md
@@ -29,6 +29,31 @@ You cannot set the `@timestamp` field in a Fluentd `record_transformer` filter.
 The plugin allows you to use some other field e.g. `time` and have that "moved"
 to a top level field called `@timestamp`.
 
+* Converts systemd and json-file logs to ViaQ data model format
+
+Doing this conversion in a `record_transformer` with embedded ruby code is very
+resource intensive.  The ViaQ plugin can convert common input formats such as
+Kubernetes `json-file`, `/var/log/messages`, and systemd `journald` into their
+corresponding ViaQ `_default_`, `systemd`, `kubernetes`, and
+`pipeline_metadata` namespaced fields.  The `pipeline_metadata` will be added
+to all records, regardless of tag.  Use the `pipeline_type` parameter to
+specify which part of the pipeline this is, `collector` or `normalizer`.
+The ViaQ data model conversion will only be applied to matching `tag`s
+specified in a `formatter` section.
+
+* Creates Elasticsearch index names or prefixes
+
+You can create either a full Elasticsearch index name for the record (to be
+used with the `fluent-plugin-elasticsearch` `target_index_key` parameter), or
+create an index name prefix (missing the date/timestamp part of the index
+name - to be used with `logstash_prefix_key`).  In order to use this, create an
+`elasticsearch_index_name` section, and specify the `tag` to match, and the
+`name_type` type of index name to create.  By default, a prefix name will be
+stored in the `viaq_index_prefix` field in the record, and a full name will be
+stored in the `viaq_index_name` field.  Configure
+`elasticsearch_index_name_field` or `elasticsearch_index_prefix_field` to use a
+different field name.
+
 ## Configuration
 
 NOTE: All fields are Optional - no required fields.
@@ -70,6 +95,49 @@ See `filter-viaq_data_model.conf` for an example filter configuration.
 * `dest_time_name` - string - default `@timestamp`
   * This is the name of the top level field to hold the time value.  The value
   is taken from the value of the `src_time_name` field.
+* `formatter` - a formatter for a well known common data model source
+  * `type` - one of the well known sources
+    * `sys_journal` - a record read from the systemd journal
+    * `k8s_journal` - a Kubernetes container record read from the systemd
+      journal - should have `CONTAINER_NAME`, `CONTAINER_ID_FULL`
+    * `sys_var_log` - a record read from `/var/log/messages`
+    * `k8s_json_file` - a record read from a `/var/log/containers/*.log` JSON
+      formatted container log file
+    * `tag` - the Fluentd tag pattern to match for these records
+    * `remove_keys` - comma delimited list of keys to remove from the record
+* `pipeline_type` - which part of the pipeline is this? `collector` or
+  `normalizer` - the default is `collector`
+* `elasticsearch_index_name` - how to construct Elasticsearch index names or
+  prefixes for given tags
+  * `tag` - the Fluentd tag pattern to match for these records
+  * `name_type` - the well known type of index name or prefix to create -
+    `operations_full, project_full, operations_prefix, project_prefix` - The
+    `operations_*` types will create a name like `.operations`, and the
+    `project_*` types will create a name like
+    `project.record['kubernetes']['namespace_name'].record['kubernetes']['namespace_id']`.
+    When using the `full` types, a delimiter `.` followed by the date in
+    `YYYY.MM.DD` format will be added to the string to make a full index name.
+    When using the `prefix` types, it is assumed that the
+    `fluent-plugin-elaticsearch` is used with the `logstash_prefix_key` to
+    create the full index name.
+* `elasticsearch_index_name_field` - name of the field in the record which stores
+  the index name - you should remove this field in the elasticsearch output
+  plugin using the `remove_keys` config parameter - default is `viaq_idnex_name`
+* `elasticsearch_index_prefix_field` - name of the field in the record which stores
+  the index prefix - you should remove this field in the elasticsearch output
+  plugin using the `remove_keys` config parameter - default is `viaq_idnex_prefix`
+
+**NOTE** The `formatter` blocks are matched in the given order in the file.
+  This means, don't use `tag "**"` as the first formatter or none of your
+  others will be matched or evaulated.
+
+**NOTE** The `elasticsearch_index_name` processing is done *last*, *after* the
+  formatting, removal of empty fields, `@timestamp` creation, etc., so use
+  e.g. `record['systemd']['t']['GID']` instead of `record['_GID']`
+
+**NOTE** The `elasticsearch_index_name` blocks are matched in the given order
+  in the file.  This means, don't use `tag "**"` as the first formatter or none
+  of your others will be matched or evaulated.
 
 ## Example
 
@@ -103,6 +171,95 @@ The resulting record, using the defaults, would look like this:
       "@timestamp": "2017-02-13 15:30:10.259106596-07:00"
     }
 
+## Formatter example
+
+Given a record like the following with a tag of `journal.system`
+
+    __REALTIME_TIMESTAMP=1502228121310282
+    __MONOTONIC_TIMESTAMP=722903835100
+    _BOOT_ID=d85e8a9d524c4a419bcfb6598db78524
+    _TRANSPORT=syslog
+    PRIORITY=6
+    SYSLOG_FACILITY=3
+    SYSLOG_IDENTIFIER=dnsmasq-dhcp
+    SYSLOG_PID=2289
+    _PID=2289
+    _UID=99
+    _GID=40
+    _COMM=dnsmasq
+    _EXE=/usr/sbin/dnsmasq
+    _CMDLINE=/sbin/dnsmasq --conf-file=/var/lib/libvirt/dnsmasq/default.conf --leasefile-ro --dhcp-script=/usr/libexec/libvirt_leaseshelper
+    _CAP_EFFECTIVE=3400
+    _SYSTEMD_CGROUP=/system.slice/libvirtd.service
+    MESSASGE=my message
+
+Using a configuration like this:
+
+    <formatter>
+      tag "journal.system**"
+      type sys_journal
+      remove_keys log,stream,MESSAGE,_SOURCE_REALTIME_TIMESTAMP,__REALTIME_TIMESTAMP,CONTAINER_ID,CONTAINER_ID_FULL,CONTAINER_NAME,PRIORITY,_BOOT_ID,_CAP_EFFECTIVE,_CMDLINE,_COMM,_EXE,_GID,_HOSTNAME,_MACHINE_ID,_PID,_SELINUX_CONTEXT,_SYSTEMD_CGROUP,_SYSTEMD_SLICE,_SYSTEMD_UNIT,_TRANSPORT,_UID,_AUDIT_LOGINUID,_AUDIT_SESSION,_SYSTEMD_OWNER_UID,_SYSTEMD_SESSION,_SYSTEMD_USER_UNIT,CODE_FILE,CODE_FUNCTION,CODE_LINE,ERRNO,MESSAGE_ID,RESULT,UNIT,_KERNEL_DEVICE,_KERNEL_SUBSYSTEM,_UDEV_SYSNAME,_UDEV_DEVNODE,_UDEV_DEVLINK,SYSLOG_FACILITY,SYSLOG_IDENTIFIER,SYSLOG_PID
+    </formatter>
+
+The resulting record will look like this:
+
+    {
+    "systemd": {
+      "t": {
+        "BOOT_ID":"d85e8a9d524c4a419bcfb6598db78524",
+        "GID":40,
+        ...
+      },
+      "u": {
+        "SYSLOG_FACILITY":3,
+        "SYSLOG_IDENTIFIER":"dnsmasq-dhcp",
+        ...
+      },
+    "message":"my message",
+    ...
+    }
+
+## Elasticsearch index name example
+
+Given a configuration like this:
+
+    <elasticsearch_index_name>
+      tag "journal.system** system.var.log** **_default_** **_openshift_** **_openshift-infra_** mux.ops"
+      name_type operations_full
+    </elasticsearch_index_name>
+    <elasticsearch_index_name>
+      tag "**"
+      name_type project_full
+    </elasticsearch_index_name>
+    elasticsearch_index_field viaq_index_name
+
+A record with tag `journal.system` like this:
+
+    {
+      "@timestamp":"2017-07-27T17:27:46.216527+00:00"
+    }
+
+will end up looking like this:
+
+    {
+      "@timestamp":"2017-07-27T17:27:46.216527+00:00",
+      "viaq_index_name":".operations.2017.07.07"
+    }
+
+A record with tag `kubernetes.journal.container` like this:
+
+    {
+      "@timestamp":"2017-07-27T17:27:46.216527+00:00",
+      "kubernetes":{"namespace_name":"myproject","namespace_id":"000000"}
+    }
+
+will end up looking like this:
+
+    {
+      "@timestamp":"2017-07-27T17:27:46.216527+00:00",
+      "kubernetes":{"namespace_name":"myproject","namespace_id":"000000"}
+      "viaq_index_name":"project.myproject.000000.2017.07.07"
+    }
 
 ## Installation
 

--- a/fluent-plugin-viaq_data_model.gemspec
+++ b/fluent-plugin-viaq_data_model.gemspec
@@ -2,9 +2,12 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
+# can override for testing
+FLUENTD_VERSION = ENV['FLUENTD_VERSION'] || "0.12.0"
+
 Gem::Specification.new do |gem|
   gem.name          = "fluent-plugin-viaq_data_model"
-  gem.version       = "0.0.5"
+  gem.version       = "0.0.6"
   gem.authors       = ["Rich Megginson"]
   gem.email         = ["rmeggins@redhat.com"]
   gem.description   = %q{Filter plugin to ensure data is in the ViaQ common data model}
@@ -20,12 +23,13 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 2.0.0'
 
-  gem.add_runtime_dependency "fluentd", ">= 0.12.0"
+  gem.add_runtime_dependency "fluentd", "~> #{FLUENTD_VERSION}"
 
   gem.add_development_dependency "bundler"
-  gem.add_development_dependency("fluentd", ">= 0.12.0")
+  gem.add_development_dependency("fluentd", "~> #{FLUENTD_VERSION}")
   gem.add_development_dependency("rake", ["~> 11.0"])
   gem.add_development_dependency("rr", ["~> 1.0"])
   gem.add_development_dependency("test-unit", ["~> 3.2"])
   gem.add_development_dependency("test-unit-rr", ["~> 1.0"])
+  gem.add_development_dependency("flexmock", ["~> 2.0"])
 end

--- a/lib/fluent/plugin/filter_viaq_data_model.rb
+++ b/lib/fluent/plugin/filter_viaq_data_model.rb
@@ -15,8 +15,39 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+require 'time'
+require 'date'
+
 require 'fluent/filter'
 require 'fluent/log'
+require 'fluent/match'
+
+begin
+  ViaqMatchClass = Fluent::Match
+rescue
+  # Fluent::Match not provided with 0.14
+  class ViaqMatchClass
+    def initialize(pattern_str, unused)
+      patterns = pattern_str.split(/\s+/).map {|str|
+        Fluent::MatchPattern.create(str)
+      }
+      if patterns.length == 1
+        @pattern = patterns[0]
+      else
+        @pattern = Fluent::OrMatchPattern.new(patterns)
+      end
+    end
+    def match(tag)
+      if @pattern.match(tag)
+        return true
+      end
+      return false
+    end
+    def to_s
+      "#{@pattern}"
+    end
+  end
+end
 
 module Fluent
   class ViaqDataModelFilter < Filter
@@ -59,6 +90,50 @@ module Fluent
     desc 'Name of destination timestamp field'
     config_param :dest_time_name, :string, default: '@timestamp'
 
+    # <formatter>
+    #   type sys_journal
+    #   tag "journal.system**"
+    #   remove_keys log,stream,MESSAGE,_SOURCE_REALTIME_TIMESTAMP,__REALTIME_TIMESTAMP,CONTAINER_ID,CONTAINER_ID_FULL,CONTAINER_NAME,PRIORITY,_BOOT_ID,_CAP_EFFECTIVE,_CMDLINE,_COMM,_EXE,_GID,_HOSTNAME,_MACHINE_ID,_PID,_SELINUX_CONTEXT,_SYSTEMD_CGROUP,_SYSTEMD_SLICE,_SYSTEMD_UNIT,_TRANSPORT,_UID,_AUDIT_LOGINUID,_AUDIT_SESSION,_SYSTEMD_OWNER_UID,_SYSTEMD_SESSION,_SYSTEMD_USER_UNIT,CODE_FILE,CODE_FUNCTION,CODE_LINE,ERRNO,MESSAGE_ID,RESULT,UNIT,_KERNEL_DEVICE,_KERNEL_SUBSYSTEM,_UDEV_SYSNAME,_UDEV_DEVNODE,_UDEV_DEVLINK,SYSLOG_FACILITY,SYSLOG_IDENTIFIER,SYSLOG_PID
+    # </formatter>
+    # formatters will be processed in the order specified, so make sure more specific matches
+    # come before more general matches
+    desc 'Formatters for common data model, for well known record types'
+    config_section :formatter, param_name: :formatters do
+      desc 'one of the well known formatter types'
+      config_param :type, :enum, list: [:sys_journal, :k8s_journal, :sys_var_log, :k8s_json_file]
+      desc 'process records with this tag pattern'
+      config_param :tag, :string
+      desc 'remove these keys from the record - same as record_transformer "remove_keys" field'
+      config_param :remove_keys, :string, default: nil
+    end
+
+    desc 'Which part of the pipeline is this - collector, normalizer, etc. for pipeline_metadata'
+    config_param :pipeline_type, :enum, list: [:collector, :normalizer], default: :collector
+
+    # e.g.
+    # <elasticsearch_index_name>
+    #   tag "journal.system** system.var.log** **_default_** **_openshift_** **_openshift-infra_** mux.ops"
+    #   name_type operations_full
+    # </elasticsearch_index_name>
+    # <elasticsearch_index_name>
+    #   tag "**"
+    #   name_type project_full
+    # </elasticsearch_index_name>
+    # operations_full - ".operations.YYYY.MM.DD"
+    # operations_prefix - ".operations"
+    # project_full - "project.${kubernetes.namespace_name}.${kubernetes.namespace_id}.YYYY.MM.DD"
+    # project_prefix - "project.${kubernetes.namespace_name}.${kubernetes.namespace_id}"
+    # index names will be processed in the order specified, so make sure more specific matches
+    # come before more general matches e.g. make sure tag "**" is last
+    desc 'Construct Elasticsearch index names or prefixes based on the matching tags pattern and type'
+    config_section :elasticsearch_index_name, param_name: :elasticsearch_index_names do
+      config_param :tag, :string
+      config_param :name_type, :enum, list: [:operations_full, :project_full, :operations_prefix, :project_prefix]
+    end
+    desc 'Store the Elasticsearch index name in this field'
+    config_param :elasticsearch_index_name_field, :string, default: 'viaq_index_name'
+    desc 'Store the Elasticsearch index prefix in this field'
+    config_param :elasticsearch_index_prefix_field, :string, default: 'viaq_index_prefix'
 
     def configure(conf)
       super
@@ -75,6 +150,43 @@ module Fluent
       end
       if (@rename_time || @rename_time_if_not_exist) && @use_undefined && !@keep_fields.key?(@src_time_name)
         raise Fluent::ConfigError, "Field [#{@src_time_name}] must be listed in default_keep_fields or extra_keep_fields"
+      end
+      if @formatters
+        @formatters.each do |fmtr|
+          matcher = ViaqMatchClass.new(fmtr.tag, nil)
+          fmtr.instance_eval{ @params[:matcher] = matcher }
+          fmtr.instance_eval{ @params[:fmtr_type] = fmtr.type }
+          if fmtr.remove_keys
+            fmtr.instance_eval{ @params[:fmtr_remove_keys] = fmtr.remove_keys.split(',') }
+          else
+            fmtr.instance_eval{ @params[:fmtr_remove_keys] = nil }
+          end
+          if fmtr.type == :sys_journal || fmtr.type == :k8s_journal
+            fmtr_func = method(:process_journal_fields)
+          elsif fmtr.type == :sys_var_log
+            fmtr_func = method(:process_sys_var_log_fields)
+          elsif fmtr.type == :k8s_json_file
+            fmtr_func = method(:process_k8s_json_file_fields)
+          end
+          fmtr.instance_eval{ @params[:fmtr_func] = fmtr_func }
+        end
+        @formatter_cache = {}
+        @formatter_cache_nomatch = {}
+      end
+      begin
+        @docker_hostname = File.open('/etc/docker-hostname') { |f| f.readline }.rstrip
+      rescue
+        @docker_hostname = nil
+      end
+      @ipaddr4 = ENV['IPADDR4'] || '127.0.0.1'
+      @ipaddr6 = ENV['IPADDR6'] || '::1'
+      @pipeline_version = (ENV['FLUENTD_VERSION'] || 'unknown fluentd version') + ' ' + (ENV['DATA_VERSION'] || 'unknown data version')
+      # create the elasticsearch index name tag matchers
+      unless @elasticsearch_index_names.empty?
+        @elasticsearch_index_names.each do |ein|
+          matcher = ViaqMatchClass.new(ein.tag, nil)
+          ein.instance_eval{ @params[:matcher] = matcher }
+        end
       end
     end
 
@@ -104,12 +216,244 @@ module Fluent
       thing
     end
 
+    # map of journal fields to viaq data model field
+    JOURNAL_FIELD_MAP_SYSTEMD_T = {
+      "_AUDIT_LOGINUID"    => "AUDIT_LOGINUID",
+      "_AUDIT_SESSION"     => "AUDIT_SESSION",
+      "_BOOT_ID"           => "BOOT_ID",
+      "_CAP_EFFECTIVE"     => "CAP_EFFECTIVE",
+      "_CMDLINE"           => "CMDLINE",
+      "_COMM"              => "COMM",
+      "_EXE"               => "EXE",
+      "_GID"               => "GID",
+      "_MACHINE_ID"        => "MACHINE_ID",
+      "_PID"               => "PID",
+      "_SELINUX_CONTEXT"   => "SELINUX_CONTEXT",
+      "_SYSTEMD_CGROUP"    => "SYSTEMD_CGROUP",
+      "_SYSTEMD_OWNER_UID" => "SYSTEMD_OWNER_UID",
+      "_SYSTEMD_SESSION"   => "SYSTEMD_SESSION",
+      "_SYSTEMD_SLICE"     => "SYSTEMD_SLICE",
+      "_SYSTEMD_UNIT"      => "SYSTEMD_UNIT",
+      "_SYSTEMD_USER_UNIT" => "SYSTEMD_USER_UNIT",
+      "_TRANSPORT"         => "TRANSPORT",
+      "_UID"               => "UID"
+    }
+
+    JOURNAL_FIELD_MAP_SYSTEMD_U = {
+      "CODE_FILE"         => "CODE_FILE",
+      "CODE_FUNCTION"     => "CODE_FUNCTION",
+      "CODE_LINE"         => "CODE_LINE",
+      "ERRNO"             => "ERRNO",
+      "MESSAGE_ID"        => "MESSAGE_ID",
+      "RESULT"            => "RESULT",
+      "UNIT"              => "UNIT",
+      "SYSLOG_FACILITY"   => "SYSLOG_FACILITY",
+      "SYSLOG_IDENTIFIER" => "SYSLOG_IDENTIFIER",
+      "SYSLOG_PID"        => "SYSLOG_PID"
+    }
+
+    JOURNAL_FIELD_MAP_SYSTEMD_K = {
+      "_KERNEL_DEVICE"    => "KERNEL_DEVICE",
+      "_KERNEL_SUBSYSTEM" => "KERNEL_SUBSYSTEM",
+      "_UDEV_SYSNAME"     => "UDEV_SYSNAME",
+      "_UDEV_DEVNODE"     => "UDEV_DEVNODE",
+      "_UDEV_DEVLINK"     => "UDEV_DEVLINK",
+    }
+
+    JOURNAL_TIME_FIELDS = ['_SOURCE_REALTIME_TIMESTAMP', '__REALTIME_TIMESTAMP']
+
+    def process_journal_fields(tag, time, record, fmtr_type)
+      systemd_t = {}
+      JOURNAL_FIELD_MAP_SYSTEMD_T.each do |jkey, key|
+        if record[jkey]
+          systemd_t[key] = record[jkey]
+        end
+      end
+      systemd_u = {}
+      JOURNAL_FIELD_MAP_SYSTEMD_U.each do |jkey, key|
+        if record[jkey]
+          systemd_u[key] = record[jkey]
+        end
+      end
+      systemd_k = {}
+      JOURNAL_FIELD_MAP_SYSTEMD_K.each do |jkey, key|
+        if record[jkey]
+          systemd_k[key] = record[jkey]
+        end
+      end
+      unless systemd_t.empty?
+        (record['systemd'] ||= {})['t'] = systemd_t
+      end
+      unless systemd_u.empty?
+        (record['systemd'] ||= {})['u'] = systemd_u
+      end
+      unless systemd_k.empty?
+        (record['systemd'] ||= {})['k'] = systemd_k
+      end
+      begin
+        pri_index = ('%d' % record['PRIORITY'] || 9).to_i
+        if pri_index < 0
+          pri_index = 9
+        elsif pri_index > 9
+          pri_index = 9
+        end
+      rescue
+        pri_index = 9
+      end
+      record['level'] = ["emerg", "alert", "crit", "err", "warning", "notice", "info", "debug", "trace", "unknown"][pri_index]
+      JOURNAL_TIME_FIELDS.each do |field|
+        if record[field]
+          record['time'] = Time.at(record[field].to_f / 1000000.0).utc.to_datetime.rfc3339(6)
+          break
+        end
+      end
+      if fmtr_type == :sys_journal
+        record['message'] = record['MESSAGE']
+        if record['_HOSTNAME'].eql?('localhost') && @docker_hostname
+          record['hostname'] = @docker_hostname
+        else
+          record['hostname'] = record['_HOSTNAME']
+        end
+      elsif fmtr_type == :k8s_journal
+        record['message'] = record['message'] || record['MESSAGE'] || record['log']
+        if record['kubernetes'] && record['kubernetes']['host']
+          record['hostname'] = record['kubernetes']['host']
+        elsif @docker_hostname
+          record['hostname'] = @docker_hostname
+        else
+          record['hostname'] = record['_HOSTNAME']
+        end
+      end
+    end
+
+    def process_sys_var_log_fields(tag, time, record, fmtr_type = nil)
+      record['systemd'] = {"t" => {"PID" => record['pid']}, "u" => {"SYSLOG_IDENTIFIER" => record['ident']}}
+      rectime = record['time'] || time
+      # handle the case where the time reported in /var/log/messages is for a previous year
+      if Time.at(rectime) > Time.now
+        record['time'] = Time.new((rectime.year - 1), rectime.month, rectime.day, rectime.hour, rectime.min, rectime.sec, rectime.utc_offset).utc.to_datetime.rfc3339(6)
+      else
+        record['time'] = rectime.utc.to_datetime.rfc3339(6)
+      end
+      if record['host'].eql?('localhost') && @docker_hostname
+        record['hostname'] = @docker_hostname
+      else
+        record['hostname'] = record['host']
+      end
+    end
+
+    def process_k8s_json_file_fields(tag, time, record, fmtr_type = nil)
+      record['message'] = record['message'] || record['log']
+      record['level'] = (record['stream'] == 'stdout') ? 'info' : 'err'
+      if record['kubernetes'] && record['kubernetes']['host']
+        record['hostname'] = record['kubernetes']['host']
+      elsif @docker_hostname
+        record['hostname'] = @docker_hostname
+      end
+      record['time'] = record['time'].utc.to_datetime.rfc3339(6)
+    end
+
+    def check_for_match_and_format(tag, time, record)
+      return unless @formatters
+      return if @formatter_cache_nomatch[tag]
+      fmtr = @formatter_cache[tag]
+      unless fmtr
+        idx = @formatters.index{|fmtr| fmtr.matcher.match(tag)}
+        if idx
+          fmtr = @formatters[idx]
+          @formatter_cache[tag] = fmtr
+        else
+          @formatter_cache_nomatch[tag] = true
+          return
+        end
+      end
+      fmtr.fmtr_func.call(tag, time, record, fmtr.fmtr_type)
+
+      if record['time'].nil?
+        record['time'] = Time.at(time).utc.to_datetime.rfc3339(6)
+      end
+
+      if fmtr.fmtr_remove_keys
+        fmtr.fmtr_remove_keys.each{|k| record.delete(k)}
+      end
+    end
+
+    def add_pipeline_metadata (tag, time, record)
+      (record['pipeline_metadata'] ||= {})[@pipeline_type.to_s] = {
+        "ipaddr4"     => @ipaddr4,
+        "ipaddr6"     => @ipaddr6,
+        "inputname"   => "fluent-plugin-systemd",
+        "name"        => "fluentd",
+        "received_at" => Time.at(time).utc.to_datetime.rfc3339(6),
+        "version"     => @pipeline_version
+      }
+    end
+
+    def add_elasticsearch_index_name_field(tag, time, record)
+      found = false
+      @elasticsearch_index_names.each do |ein|
+        if ein.matcher.match(tag)
+          found = true
+          if ein.name_type == :operations_full || ein.name_type == :project_full
+            field_name = @elasticsearch_index_name_field
+            need_time = true
+          else
+            field_name = @elasticsearch_index_prefix_field
+            need_time = false
+          end
+
+          if ein.name_type == :operations_full || ein.name_type == :operations_prefix
+            prefix = ".operations"
+          elsif ein.name_type == :project_full || ein.name_type == :project_prefix
+            if (k8s = record['kubernetes']).nil?
+              log.error("record cannot use elasticsearch index name type #{ein.name_type}: record is missing kubernetes field: #{record}")
+              break
+            elsif (name = k8s['namespace_name']).nil?
+              log.error("record cannot use elasticsearch index name type #{ein.name_type}: record is missing kubernetes.namespace_name field: #{record}")
+              break
+            elsif (uuid = k8s['namespace_id']).nil?
+              log.error("record cannot use elasticsearch index name type #{ein.name_type}: record is missing kubernetes.namespace_id field: #{record}")
+              break
+            else
+              prefix = "project." + name + "." + uuid
+            end
+          end
+
+          if ENV['CDM_DEBUG']
+            unless tag == ENV['CDM_DEBUG_IGNORE_TAG']
+              log.error("prefix #{prefix} need_time #{need_time} time #{record[@dest_time_name]}")
+            end
+          end
+
+          if need_time
+            ts = DateTime.parse(record[@dest_time_name])
+            record[field_name] = prefix + "." + ts.strftime("%Y.%m.%d")
+          else
+            record[field_name] = prefix
+          end
+          if ENV['CDM_DEBUG']
+            unless tag == ENV['CDM_DEBUG_IGNORE_TAG']
+              log.error("record[#{field_name}] = #{record[field_name]}")
+            end
+          end
+
+          break
+        end
+      end
+      unless found
+        log.warn("no match for tag #{tag}")
+      end
+    end
+
     def filter(tag, time, record)
       if ENV['CDM_DEBUG']
         unless tag == ENV['CDM_DEBUG_IGNORE_TAG']
           log.error("input #{time} #{tag} #{record}")
         end
       end
+
+      check_for_match_and_format(tag, time, record)
+      add_pipeline_metadata(tag, time, record)
       if @use_undefined
         # undefined contains all of the fields not in keep_fields
         undefined = record.reject{|k,v| @keep_fields.key?(k)}
@@ -130,6 +474,14 @@ module Fluent
         val = record.delete(@src_time_name)
         unless @rename_time_if_missing && record.key?(@dest_time_name)
           record[@dest_time_name] = val
+        end
+      end
+
+      if !@elasticsearch_index_names.empty?
+        add_elasticsearch_index_name_field(tag, time, record)
+      elsif ENV['CDM_DEBUG']
+        unless tag == ENV['CDM_DEBUG_IGNORE_TAG']
+          log.error("not adding elasticsearch index name or prefix")
         end
       end
       if ENV['CDM_DEBUG']

--- a/lib/fluent/plugin/filter_viaq_data_model_systemd.rb
+++ b/lib/fluent/plugin/filter_viaq_data_model_systemd.rb
@@ -1,0 +1,133 @@
+#
+# Fluentd ViaQ data model Filter Plugin
+#
+# Copyright 2017 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+require 'time'
+require 'date'
+
+module ViaqDataModelFilterSystemd
+  # map of journal fields to viaq data model field
+  JOURNAL_FIELD_MAP_SYSTEMD_T = {
+    "_AUDIT_LOGINUID"    => "AUDIT_LOGINUID",
+    "_AUDIT_SESSION"     => "AUDIT_SESSION",
+    "_BOOT_ID"           => "BOOT_ID",
+    "_CAP_EFFECTIVE"     => "CAP_EFFECTIVE",
+    "_CMDLINE"           => "CMDLINE",
+    "_COMM"              => "COMM",
+    "_EXE"               => "EXE",
+    "_GID"               => "GID",
+    "_MACHINE_ID"        => "MACHINE_ID",
+    "_PID"               => "PID",
+    "_SELINUX_CONTEXT"   => "SELINUX_CONTEXT",
+    "_SYSTEMD_CGROUP"    => "SYSTEMD_CGROUP",
+    "_SYSTEMD_OWNER_UID" => "SYSTEMD_OWNER_UID",
+    "_SYSTEMD_SESSION"   => "SYSTEMD_SESSION",
+    "_SYSTEMD_SLICE"     => "SYSTEMD_SLICE",
+    "_SYSTEMD_UNIT"      => "SYSTEMD_UNIT",
+    "_SYSTEMD_USER_UNIT" => "SYSTEMD_USER_UNIT",
+    "_TRANSPORT"         => "TRANSPORT",
+    "_UID"               => "UID"
+  }
+
+  JOURNAL_FIELD_MAP_SYSTEMD_U = {
+    "CODE_FILE"         => "CODE_FILE",
+    "CODE_FUNCTION"     => "CODE_FUNCTION",
+    "CODE_LINE"         => "CODE_LINE",
+    "ERRNO"             => "ERRNO",
+    "MESSAGE_ID"        => "MESSAGE_ID",
+    "RESULT"            => "RESULT",
+    "UNIT"              => "UNIT",
+    "SYSLOG_FACILITY"   => "SYSLOG_FACILITY",
+    "SYSLOG_IDENTIFIER" => "SYSLOG_IDENTIFIER",
+    "SYSLOG_PID"        => "SYSLOG_PID"
+  }
+
+  JOURNAL_FIELD_MAP_SYSTEMD_K = {
+    "_KERNEL_DEVICE"    => "KERNEL_DEVICE",
+    "_KERNEL_SUBSYSTEM" => "KERNEL_SUBSYSTEM",
+    "_UDEV_SYSNAME"     => "UDEV_SYSNAME",
+    "_UDEV_DEVNODE"     => "UDEV_DEVNODE",
+    "_UDEV_DEVLINK"     => "UDEV_DEVLINK",
+  }
+
+  JOURNAL_TIME_FIELDS = ['_SOURCE_REALTIME_TIMESTAMP', '__REALTIME_TIMESTAMP']
+
+  def process_journal_fields(tag, time, record, fmtr_type)
+    systemd_t = {}
+    JOURNAL_FIELD_MAP_SYSTEMD_T.each do |jkey, key|
+      if record[jkey]
+        systemd_t[key] = record[jkey]
+      end
+    end
+    systemd_u = {}
+    JOURNAL_FIELD_MAP_SYSTEMD_U.each do |jkey, key|
+      if record[jkey]
+        systemd_u[key] = record[jkey]
+      end
+    end
+    systemd_k = {}
+    JOURNAL_FIELD_MAP_SYSTEMD_K.each do |jkey, key|
+      if record[jkey]
+        systemd_k[key] = record[jkey]
+      end
+    end
+    unless systemd_t.empty?
+      (record['systemd'] ||= {})['t'] = systemd_t
+    end
+    unless systemd_u.empty?
+      (record['systemd'] ||= {})['u'] = systemd_u
+    end
+    unless systemd_k.empty?
+      (record['systemd'] ||= {})['k'] = systemd_k
+    end
+    begin
+      pri_index = ('%d' % record['PRIORITY'] || 9).to_i
+      case
+      when pri_index < 0
+        pri_index = 9
+      when pri_index > 9
+        pri_index = 9
+      end
+    rescue
+      pri_index = 9
+    end
+    record['level'] = ["emerg", "alert", "crit", "err", "warning", "notice", "info", "debug", "trace", "unknown"][pri_index]
+    JOURNAL_TIME_FIELDS.each do |field|
+      if record[field]
+        record['time'] = Time.at(record[field].to_f / 1000000.0).utc.to_datetime.rfc3339(6)
+        break
+      end
+    end
+    case fmtr_type
+    when :sys_journal
+      record['message'] = record['MESSAGE']
+      if record['_HOSTNAME'].eql?('localhost') && @docker_hostname
+        record['hostname'] = @docker_hostname
+      else
+        record['hostname'] = record['_HOSTNAME']
+      end
+    when :k8s_journal
+      record['message'] = record['message'] || record['MESSAGE'] || record['log']
+      if record['kubernetes'] && record['kubernetes']['host']
+        record['hostname'] = record['kubernetes']['host']
+      elsif @docker_hostname
+        record['hostname'] = @docker_hostname
+      else
+        record['hostname'] = record['_HOSTNAME']
+      end
+    end
+  end
+end

--- a/test/test_filter_viaq_data_model.rb
+++ b/test/test_filter_viaq_data_model.rb
@@ -31,7 +31,9 @@ class ViaqDataModelFilterTest < Test::Unit::TestCase
   end
 
   def create_driver(conf = '')
-    Test::FilterTestDriver.new(ViaqDataModelFilter, 'this.is.a.tag').configure(conf, true)
+    d = Test::FilterTestDriver.new(ViaqDataModelFilter, 'this.is.a.tag').configure(conf, true)
+    @dlog = d.instance.log
+    d
   end
 
   sub_test_case 'configure' do
@@ -212,6 +214,657 @@ class ViaqDataModelFilterTest < Test::Unit::TestCase
       assert_equal([88], rec['h']['i']['m'])
       assert_true(rec['h']['i']['n'])
     end
+  end
 
+  sub_test_case 'formatters and elasticsearch index names' do
+    def emit_with_tag(tag, msg={}, conf='')
+      d = create_driver(conf)
+      d.run {
+        d.emit_with_tag(tag, msg, @time)
+      }.filtered.instance_variable_get(:@record_array)[0]
+    end
+
+    def normal_input
+      {
+        "_AUDIT_LOGINUID"            => "AUDIT_LOGINUID",
+        "_AUDIT_SESSION"             => "AUDIT_SESSION",
+        "_BOOT_ID"                   => "BOOT_ID",
+        "_CAP_EFFECTIVE"             => "CAP_EFFECTIVE",
+        "_CMDLINE"                   => "CMDLINE",
+        "_COMM"                      => "COMM",
+        "_EXE"                       => "EXE",
+        "_GID"                       => "GID",
+        "_MACHINE_ID"                => "MACHINE_ID",
+        "_PID"                       => "PID",
+        "_SELINUX_CONTEXT"           => "SELINUX_CONTEXT",
+        "_SYSTEMD_CGROUP"            => "SYSTEMD_CGROUP",
+        "_SYSTEMD_OWNER_UID"         => "SYSTEMD_OWNER_UID",
+        "_SYSTEMD_SESSION"           => "SYSTEMD_SESSION",
+        "_SYSTEMD_SLICE"             => "SYSTEMD_SLICE",
+        "_SYSTEMD_UNIT"              => "SYSTEMD_UNIT",
+        "_SYSTEMD_USER_UNIT"         => "SYSTEMD_USER_UNIT",
+        "_TRANSPORT"                 => "TRANSPORT",
+        "_UID"                       => "UID",
+        "CODE_FILE"                  => "CODE_FILE",
+        "CODE_FUNCTION"              => "CODE_FUNCTION",
+        "CODE_LINE"                  => "CODE_LINE",
+        "ERRNO"                      => "ERRNO",
+        "MESSAGE_ID"                 => "MESSAGE_ID",
+        "RESULT"                     => "RESULT",
+        "UNIT"                       => "UNIT",
+        "SYSLOG_FACILITY"            => "SYSLOG_FACILITY",
+        "SYSLOG_IDENTIFIER"          => "SYSLOG_IDENTIFIER",
+        "SYSLOG_PID"                 => "SYSLOG_PID",
+        "_KERNEL_DEVICE"             => "KERNEL_DEVICE",
+        "_KERNEL_SUBSYSTEM"          => "KERNEL_SUBSYSTEM",
+        "_UDEV_SYSNAME"              => "UDEV_SYSNAME",
+        "_UDEV_DEVNODE"              => "UDEV_DEVNODE",
+        "_UDEV_DEVLINK"              => "UDEV_DEVLINK",
+        "_SOURCE_REALTIME_TIMESTAMP" => "1501176466216527",
+        "__REALTIME_TIMESTAMP"       => "1501176466216527",
+        "MESSAGE"                    => "hello world",
+        "PRIORITY"                   => "6",
+        "_HOSTNAME"                  => "myhost"
+      }
+    end
+    def normal_output_t
+      {
+        "AUDIT_LOGINUID"    =>"AUDIT_LOGINUID",
+        "AUDIT_SESSION"     =>"AUDIT_SESSION",
+        "BOOT_ID"           =>"BOOT_ID",
+        "CAP_EFFECTIVE"     =>"CAP_EFFECTIVE",
+        "CMDLINE"           =>"CMDLINE",
+        "COMM"              =>"COMM",
+        "EXE"               =>"EXE",
+        "GID"               =>"GID",
+        "MACHINE_ID"        =>"MACHINE_ID",
+        "PID"               =>"PID",
+        "SELINUX_CONTEXT"   =>"SELINUX_CONTEXT",
+        "SYSTEMD_CGROUP"    =>"SYSTEMD_CGROUP",
+        "SYSTEMD_OWNER_UID" =>"SYSTEMD_OWNER_UID",
+        "SYSTEMD_SESSION"   =>"SYSTEMD_SESSION",
+        "SYSTEMD_SLICE"     =>"SYSTEMD_SLICE",
+        "SYSTEMD_UNIT"      =>"SYSTEMD_UNIT",
+        "SYSTEMD_USER_UNIT" =>"SYSTEMD_USER_UNIT",
+        "TRANSPORT"         =>"TRANSPORT",
+        "UID"               =>"UID"
+      }
+    end
+    def normal_output_u
+      {
+        "CODE_FILE"         =>"CODE_FILE",
+        "CODE_FUNCTION"     =>"CODE_FUNCTION",
+        "CODE_LINE"         =>"CODE_LINE",
+        "ERRNO"             =>"ERRNO",
+        "MESSAGE_ID"        =>"MESSAGE_ID",
+        "RESULT"            =>"RESULT",
+        "UNIT"              =>"UNIT",
+        "SYSLOG_FACILITY"   =>"SYSLOG_FACILITY",
+        "SYSLOG_IDENTIFIER" =>"SYSLOG_IDENTIFIER",
+        "SYSLOG_PID"        =>"SYSLOG_PID"
+      }
+    end
+    def normal_output_k
+      {
+        "KERNEL_DEVICE"    =>"KERNEL_DEVICE",
+        "KERNEL_SUBSYSTEM" =>"KERNEL_SUBSYSTEM",
+        "UDEV_SYSNAME"     =>"UDEV_SYSNAME",
+        "UDEV_DEVNODE"     =>"UDEV_DEVNODE",
+        "UDEV_DEVLINK"     =>"UDEV_DEVLINK"
+      }
+    end
+    test 'match records with journal_system_record_tag' do
+      rec = emit_with_tag('journal.system', {'a'=>'b', 'MESSAGE'=>'here'}, '
+        <formatter>
+          tag "**do_not_match**"
+          type sys_journal
+          remove_keys a,message
+        </formatter>
+        <formatter>
+          tag "journal.system**"
+          type sys_journal
+        </formatter>
+        <formatter>
+          tag "**"
+          type sys_journal
+          remove_keys a,message
+        </formatter>
+      ')
+      assert_equal('b', rec['a'])
+      assert_equal('here', rec['message'])
+    end
+    test 'do not match records without journal_system_record_tag' do
+      rec = emit_with_tag('journal.systm', {'a'=>'b', 'MESSAGE'=>'here'}, '
+        <formatter>
+          tag "journal.system**"
+          type sys_journal
+        </formatter>
+      ')
+      assert_equal('b', rec['a'])
+      assert_equal('here', rec['MESSAGE'])
+    end
+    test 'process a journal record, default settings' do
+      ENV['IPADDR4'] = '127.0.0.1'
+      ENV['IPADDR6'] = '::1'
+      ENV['FLUENTD_VERSION'] = 'fversion'
+      ENV['DATA_VERSION'] = 'dversion'
+      rec = emit_with_tag('journal.system', normal_input, '
+        <formatter>
+          tag "journal.system**"
+          type sys_journal
+          remove_keys log,stream,MESSAGE,_SOURCE_REALTIME_TIMESTAMP,__REALTIME_TIMESTAMP,CONTAINER_ID,CONTAINER_ID_FULL,CONTAINER_NAME,PRIORITY,_BOOT_ID,_CAP_EFFECTIVE,_CMDLINE,_COMM,_EXE,_GID,_HOSTNAME,_MACHINE_ID,_PID,_SELINUX_CONTEXT,_SYSTEMD_CGROUP,_SYSTEMD_SLICE,_SYSTEMD_UNIT,_TRANSPORT,_UID,_AUDIT_LOGINUID,_AUDIT_SESSION,_SYSTEMD_OWNER_UID,_SYSTEMD_SESSION,_SYSTEMD_USER_UNIT,CODE_FILE,CODE_FUNCTION,CODE_LINE,ERRNO,MESSAGE_ID,RESULT,UNIT,_KERNEL_DEVICE,_KERNEL_SUBSYSTEM,_UDEV_SYSNAME,_UDEV_DEVNODE,_UDEV_DEVLINK,SYSLOG_FACILITY,SYSLOG_IDENTIFIER,SYSLOG_PID
+        </formatter>
+        pipeline_type normalizer
+      ')
+      assert_equal(normal_output_t, rec['systemd']['t'])
+      assert_equal(normal_output_u, rec['systemd']['u'])
+      assert_equal(normal_output_k, rec['systemd']['k'])
+      assert_equal('hello world', rec['message'])
+      assert_equal('info', rec['level'])
+      assert_equal('myhost', rec['hostname'])
+      assert_equal('2017-07-27T17:27:46.216527+00:00', rec['@timestamp'])
+      assert_equal('127.0.0.1', rec['pipeline_metadata']['normalizer']['ipaddr4'])
+      assert_equal('::1', rec['pipeline_metadata']['normalizer']['ipaddr6'])
+      assert_equal('fluent-plugin-systemd', rec['pipeline_metadata']['normalizer']['inputname'])
+      assert_equal('fluentd', rec['pipeline_metadata']['normalizer']['name'])
+      assert_equal('fversion dversion', rec['pipeline_metadata']['normalizer']['version'])
+      assert_equal(Time.at(@time).utc.to_datetime.rfc3339(6), rec['pipeline_metadata']['normalizer']['received_at'])
+      dellist = 'log,stream,MESSAGE,_SOURCE_REALTIME_TIMESTAMP,__REALTIME_TIMESTAMP,CONTAINER_ID,CONTAINER_ID_FULL,CONTAINER_NAME,PRIORITY,_BOOT_ID,_CAP_EFFECTIVE,_CMDLINE,_COMM,_EXE,_GID,_HOSTNAME,_MACHINE_ID,_PID,_SELINUX_CONTEXT,_SYSTEMD_CGROUP,_SYSTEMD_SLICE,_SYSTEMD_UNIT,_TRANSPORT,_UID,_AUDIT_LOGINUID,_AUDIT_SESSION,_SYSTEMD_OWNER_UID,_SYSTEMD_SESSION,_SYSTEMD_USER_UNIT,CODE_FILE,CODE_FUNCTION,CODE_LINE,ERRNO,MESSAGE_ID,RESULT,UNIT,_KERNEL_DEVICE,_KERNEL_SUBSYSTEM,_UDEV_SYSNAME,_UDEV_DEVNODE,_UDEV_DEVLINK,SYSLOG_FACILITY,SYSLOG_IDENTIFIER,SYSLOG_PID'.split(',')
+      dellist.each{|field| assert_nil(rec[field])}
+    end
+    test 'process a journal record, override remove_keys' do
+      ENV['IPADDR4'] = '127.0.0.1'
+      ENV['IPADDR6'] = '::1'
+      ENV['FLUENTD_VERSION'] = 'fversion'
+      ENV['DATA_VERSION'] = 'dversion'
+      rec = emit_with_tag('journal.system', normal_input, '
+        <formatter>
+          tag "journal.system**"
+          type sys_journal
+          remove_keys CONTAINER_NAME,PRIORITY
+        </formatter>
+        pipeline_type normalizer
+      ')
+      assert_equal(normal_output_t, rec['systemd']['t'])
+      assert_equal(normal_output_u, rec['systemd']['u'])
+      assert_equal(normal_output_k, rec['systemd']['k'])
+      assert_equal('hello world', rec['message'])
+      assert_equal('info', rec['level'])
+      assert_equal('myhost', rec['hostname'])
+      assert_equal('2017-07-27T17:27:46.216527+00:00', rec['@timestamp'])
+      assert_equal('127.0.0.1', rec['pipeline_metadata']['normalizer']['ipaddr4'])
+      assert_equal('::1', rec['pipeline_metadata']['normalizer']['ipaddr6'])
+      assert_equal('fluent-plugin-systemd', rec['pipeline_metadata']['normalizer']['inputname'])
+      assert_equal('fluentd', rec['pipeline_metadata']['normalizer']['name'])
+      assert_equal('fversion dversion', rec['pipeline_metadata']['normalizer']['version'])
+      assert_equal(Time.at(@time).utc.to_datetime.rfc3339(6), rec['pipeline_metadata']['normalizer']['received_at'])
+      keeplist = 'log,stream,MESSAGE,_SOURCE_REALTIME_TIMESTAMP,__REALTIME_TIMESTAMP,CONTAINER_ID,CONTAINER_ID_FULL,_BOOT_ID,_CAP_EFFECTIVE,_CMDLINE,_COMM,_EXE,_GID,_HOSTNAME,_MACHINE_ID,_PID,_SELINUX_CONTEXT,_SYSTEMD_CGROUP,_SYSTEMD_SLICE,_SYSTEMD_UNIT,_TRANSPORT,_UID,_AUDIT_LOGINUID,_AUDIT_SESSION,_SYSTEMD_OWNER_UID,_SYSTEMD_SESSION,_SYSTEMD_USER_UNIT,CODE_FILE,CODE_FUNCTION,CODE_LINE,ERRNO,MESSAGE_ID,RESULT,UNIT,_KERNEL_DEVICE,_KERNEL_SUBSYSTEM,_UDEV_SYSNAME,_UDEV_DEVNODE,_UDEV_DEVLINK,SYSLOG_FACILITY,SYSLOG_IDENTIFIER,SYSLOG_PID'.split(',')
+      keeplist.each{|field| normal_input[field] && assert_not_nil(rec[field])}
+      dellist = 'CONTAINER_NAME,PRIORITY'.split(',')
+      dellist.each{|field| assert_nil(rec[field])}
+    end
+    test 'try a PRIORITY value that is too large' do
+      rec = emit_with_tag('journal.system', {'a'=>'b', 'PRIORITY'=>'10'}, '
+        <formatter>
+          tag "journal.system**"
+          type sys_journal
+        </formatter>
+      ')
+      assert_equal('b', rec['a'])
+      assert_equal('unknown', rec['level'])
+    end
+    test 'try a PRIORITY value that is too small' do
+      rec = emit_with_tag('journal.system', {'a'=>'b', 'PRIORITY'=>'-1'}, '
+        <formatter>
+          tag "journal.system**"
+          type sys_journal
+        </formatter>
+      ')
+      assert_equal('b', rec['a'])
+      assert_equal('unknown', rec['level'])
+    end
+    test 'try a PRIORITY value that is not a number' do
+      rec = emit_with_tag('journal.system', {'a'=>'b', 'PRIORITY'=>'NaN'}, '
+        <formatter>
+          tag "journal.system**"
+          type sys_journal
+        </formatter>
+      ')
+      assert_equal('b', rec['a'])
+      assert_equal('unknown', rec['level'])
+    end
+    test 'try a PRIORITY value that is a floating point number' do
+      rec = emit_with_tag('journal.system', {'a'=>'b', 'PRIORITY'=>'1.0'}, '
+        <formatter>
+          tag "journal.system**"
+          type sys_journal
+        </formatter>
+      ')
+      assert_equal('b', rec['a'])
+      assert_equal('unknown', rec['level'])
+    end
+    test 'test with fallback to __REALTIME_TIMESTAMP' do
+      input = normal_input.reject{|k,v| k == '_SOURCE_REALTIME_TIMESTAMP'}
+      rec = emit_with_tag('journal.system', input, '
+        <formatter>
+          tag "journal.system**"
+          type sys_journal
+        </formatter>
+      ')
+      assert_equal('2017-07-27T17:27:46.216527+00:00', rec['@timestamp'])
+    end
+    test 'test using internal time if no timestamp given' do
+      input = normal_input.reject do |k,v|
+        k == '_SOURCE_REALTIME_TIMESTAMP' || k == '__REALTIME_TIMESTAMP'
+      end
+      rec = emit_with_tag('journal.system', input, '
+        <formatter>
+          tag "journal.system**"
+          type sys_journal
+        </formatter>
+      ')
+      assert_equal(Time.at(@time).utc.to_datetime.rfc3339(6), rec['@timestamp'])
+    end
+    test 'process a kubernetes journal record, default settings' do
+      ENV['IPADDR4'] = '127.0.0.1'
+      ENV['IPADDR6'] = '::1'
+      ENV['FLUENTD_VERSION'] = 'fversion'
+      ENV['DATA_VERSION'] = 'dversion'
+      rec = emit_with_tag('kubernetes.journal.container', normal_input, '
+        <formatter>
+          tag "kubernetes.journal.container**"
+          type k8s_journal
+          remove_keys log,stream,MESSAGE,_SOURCE_REALTIME_TIMESTAMP,__REALTIME_TIMESTAMP,CONTAINER_ID,CONTAINER_ID_FULL,CONTAINER_NAME,PRIORITY,_BOOT_ID,_CAP_EFFECTIVE,_CMDLINE,_COMM,_EXE,_GID,_HOSTNAME,_MACHINE_ID,_PID,_SELINUX_CONTEXT,_SYSTEMD_CGROUP,_SYSTEMD_SLICE,_SYSTEMD_UNIT,_TRANSPORT,_UID,_AUDIT_LOGINUID,_AUDIT_SESSION,_SYSTEMD_OWNER_UID,_SYSTEMD_SESSION,_SYSTEMD_USER_UNIT,CODE_FILE,CODE_FUNCTION,CODE_LINE,ERRNO,MESSAGE_ID,RESULT,UNIT,_KERNEL_DEVICE,_KERNEL_SUBSYSTEM,_UDEV_SYSNAME,_UDEV_DEVNODE,_UDEV_DEVLINK,SYSLOG_FACILITY,SYSLOG_IDENTIFIER,SYSLOG_PID
+        </formatter>
+        pipeline_type normalizer
+      ')
+      assert_equal(normal_output_t, rec['systemd']['t'])
+      assert_equal(normal_output_u, rec['systemd']['u'])
+      assert_equal(normal_output_k, rec['systemd']['k'])
+      assert_equal('hello world', rec['message'])
+      assert_equal('info', rec['level'])
+      assert_equal('myhost', rec['hostname'])
+      assert_equal('2017-07-27T17:27:46.216527+00:00', rec['@timestamp'])
+      assert_equal('127.0.0.1', rec['pipeline_metadata']['normalizer']['ipaddr4'])
+      assert_equal('::1', rec['pipeline_metadata']['normalizer']['ipaddr6'])
+      assert_equal('fluent-plugin-systemd', rec['pipeline_metadata']['normalizer']['inputname'])
+      assert_equal('fluentd', rec['pipeline_metadata']['normalizer']['name'])
+      assert_equal('fversion dversion', rec['pipeline_metadata']['normalizer']['version'])
+      assert_equal(Time.at(@time).utc.to_datetime.rfc3339(6), rec['pipeline_metadata']['normalizer']['received_at'])
+      dellist = 'log,stream,MESSAGE,_SOURCE_REALTIME_TIMESTAMP,__REALTIME_TIMESTAMP,CONTAINER_ID,CONTAINER_ID_FULL,CONTAINER_NAME,PRIORITY,_BOOT_ID,_CAP_EFFECTIVE,_CMDLINE,_COMM,_EXE,_GID,_HOSTNAME,_MACHINE_ID,_PID,_SELINUX_CONTEXT,_SYSTEMD_CGROUP,_SYSTEMD_SLICE,_SYSTEMD_UNIT,_TRANSPORT,_UID,_AUDIT_LOGINUID,_AUDIT_SESSION,_SYSTEMD_OWNER_UID,_SYSTEMD_SESSION,_SYSTEMD_USER_UNIT,CODE_FILE,CODE_FUNCTION,CODE_LINE,ERRNO,MESSAGE_ID,RESULT,UNIT,_KERNEL_DEVICE,_KERNEL_SUBSYSTEM,_UDEV_SYSNAME,_UDEV_DEVNODE,_UDEV_DEVLINK,SYSLOG_FACILITY,SYSLOG_IDENTIFIER,SYSLOG_PID'.split(',')
+      dellist.each{|field| assert_nil(rec[field])}
+    end
+    test 'process a kubernetes journal record, given kubernetes.host' do
+      input = normal_input.merge({})
+      input['kubernetes'] = {'host' => 'k8shost'}
+      ENV['IPADDR4'] = '127.0.0.1'
+      ENV['IPADDR6'] = '::1'
+      ENV['FLUENTD_VERSION'] = 'fversion'
+      ENV['DATA_VERSION'] = 'dversion'
+      rec = emit_with_tag('kubernetes.journal.container', input, '
+        <formatter>
+          tag "kubernetes.journal.container**"
+          type k8s_journal
+          remove_keys log,stream,MESSAGE,_SOURCE_REALTIME_TIMESTAMP,__REALTIME_TIMESTAMP,CONTAINER_ID,CONTAINER_ID_FULL,CONTAINER_NAME,PRIORITY,_BOOT_ID,_CAP_EFFECTIVE,_CMDLINE,_COMM,_EXE,_GID,_HOSTNAME,_MACHINE_ID,_PID,_SELINUX_CONTEXT,_SYSTEMD_CGROUP,_SYSTEMD_SLICE,_SYSTEMD_UNIT,_TRANSPORT,_UID,_AUDIT_LOGINUID,_AUDIT_SESSION,_SYSTEMD_OWNER_UID,_SYSTEMD_SESSION,_SYSTEMD_USER_UNIT,CODE_FILE,CODE_FUNCTION,CODE_LINE,ERRNO,MESSAGE_ID,RESULT,UNIT,_KERNEL_DEVICE,_KERNEL_SUBSYSTEM,_UDEV_SYSNAME,_UDEV_DEVNODE,_UDEV_DEVLINK,SYSLOG_FACILITY,SYSLOG_IDENTIFIER,SYSLOG_PID
+        </formatter>
+        pipeline_type normalizer
+      ')
+      assert_equal(normal_output_t, rec['systemd']['t'])
+      assert_equal(normal_output_u, rec['systemd']['u'])
+      assert_equal(normal_output_k, rec['systemd']['k'])
+      assert_equal('hello world', rec['message'])
+      assert_equal('info', rec['level'])
+      assert_equal('k8shost', rec['hostname'])
+      assert_equal('2017-07-27T17:27:46.216527+00:00', rec['@timestamp'])
+      assert_equal('127.0.0.1', rec['pipeline_metadata']['normalizer']['ipaddr4'])
+      assert_equal('::1', rec['pipeline_metadata']['normalizer']['ipaddr6'])
+      assert_equal('fluent-plugin-systemd', rec['pipeline_metadata']['normalizer']['inputname'])
+      assert_equal('fluentd', rec['pipeline_metadata']['normalizer']['name'])
+      assert_equal('fversion dversion', rec['pipeline_metadata']['normalizer']['version'])
+      assert_equal(Time.at(@time).utc.to_datetime.rfc3339(6), rec['pipeline_metadata']['normalizer']['received_at'])
+      dellist = 'log,stream,MESSAGE,_SOURCE_REALTIME_TIMESTAMP,__REALTIME_TIMESTAMP,CONTAINER_ID,CONTAINER_ID_FULL,CONTAINER_NAME,PRIORITY,_BOOT_ID,_CAP_EFFECTIVE,_CMDLINE,_COMM,_EXE,_GID,_HOSTNAME,_MACHINE_ID,_PID,_SELINUX_CONTEXT,_SYSTEMD_CGROUP,_SYSTEMD_SLICE,_SYSTEMD_UNIT,_TRANSPORT,_UID,_AUDIT_LOGINUID,_AUDIT_SESSION,_SYSTEMD_OWNER_UID,_SYSTEMD_SESSION,_SYSTEMD_USER_UNIT,CODE_FILE,CODE_FUNCTION,CODE_LINE,ERRNO,MESSAGE_ID,RESULT,UNIT,_KERNEL_DEVICE,_KERNEL_SUBSYSTEM,_UDEV_SYSNAME,_UDEV_DEVNODE,_UDEV_DEVLINK,SYSLOG_FACILITY,SYSLOG_IDENTIFIER,SYSLOG_PID'.split(',')
+      dellist.each{|field| assert_nil(rec[field])}
+    end
+    test 'process a kubernetes journal record, preserve message field' do
+      input = normal_input.merge({})
+      input['message'] = 'my message'
+      ENV['IPADDR4'] = '127.0.0.1'
+      ENV['IPADDR6'] = '::1'
+      ENV['FLUENTD_VERSION'] = 'fversion'
+      ENV['DATA_VERSION'] = 'dversion'
+      rec = emit_with_tag('kubernetes.journal.container', input, '
+        <formatter>
+          tag "kubernetes.journal.container**"
+          type k8s_journal
+          remove_keys log,stream,MESSAGE,_SOURCE_REALTIME_TIMESTAMP,__REALTIME_TIMESTAMP,CONTAINER_ID,CONTAINER_ID_FULL,CONTAINER_NAME,PRIORITY,_BOOT_ID,_CAP_EFFECTIVE,_CMDLINE,_COMM,_EXE,_GID,_HOSTNAME,_MACHINE_ID,_PID,_SELINUX_CONTEXT,_SYSTEMD_CGROUP,_SYSTEMD_SLICE,_SYSTEMD_UNIT,_TRANSPORT,_UID,_AUDIT_LOGINUID,_AUDIT_SESSION,_SYSTEMD_OWNER_UID,_SYSTEMD_SESSION,_SYSTEMD_USER_UNIT,CODE_FILE,CODE_FUNCTION,CODE_LINE,ERRNO,MESSAGE_ID,RESULT,UNIT,_KERNEL_DEVICE,_KERNEL_SUBSYSTEM,_UDEV_SYSNAME,_UDEV_DEVNODE,_UDEV_DEVLINK,SYSLOG_FACILITY,SYSLOG_IDENTIFIER,SYSLOG_PID
+        </formatter>
+        pipeline_type normalizer
+      ')
+      assert_equal(normal_output_t, rec['systemd']['t'])
+      assert_equal(normal_output_u, rec['systemd']['u'])
+      assert_equal(normal_output_k, rec['systemd']['k'])
+      assert_equal('my message', rec['message'])
+      assert_equal('info', rec['level'])
+      assert_equal('myhost', rec['hostname'])
+      assert_equal('2017-07-27T17:27:46.216527+00:00', rec['@timestamp'])
+      assert_equal('127.0.0.1', rec['pipeline_metadata']['normalizer']['ipaddr4'])
+      assert_equal('::1', rec['pipeline_metadata']['normalizer']['ipaddr6'])
+      assert_equal('fluent-plugin-systemd', rec['pipeline_metadata']['normalizer']['inputname'])
+      assert_equal('fluentd', rec['pipeline_metadata']['normalizer']['name'])
+      assert_equal('fversion dversion', rec['pipeline_metadata']['normalizer']['version'])
+      assert_equal(Time.at(@time).utc.to_datetime.rfc3339(6), rec['pipeline_metadata']['normalizer']['received_at'])
+      dellist = 'log,stream,MESSAGE,_SOURCE_REALTIME_TIMESTAMP,__REALTIME_TIMESTAMP,CONTAINER_ID,CONTAINER_ID_FULL,CONTAINER_NAME,PRIORITY,_BOOT_ID,_CAP_EFFECTIVE,_CMDLINE,_COMM,_EXE,_GID,_HOSTNAME,_MACHINE_ID,_PID,_SELINUX_CONTEXT,_SYSTEMD_CGROUP,_SYSTEMD_SLICE,_SYSTEMD_UNIT,_TRANSPORT,_UID,_AUDIT_LOGINUID,_AUDIT_SESSION,_SYSTEMD_OWNER_UID,_SYSTEMD_SESSION,_SYSTEMD_USER_UNIT,CODE_FILE,CODE_FUNCTION,CODE_LINE,ERRNO,MESSAGE_ID,RESULT,UNIT,_KERNEL_DEVICE,_KERNEL_SUBSYSTEM,_UDEV_SYSNAME,_UDEV_DEVNODE,_UDEV_DEVLINK,SYSLOG_FACILITY,SYSLOG_IDENTIFIER,SYSLOG_PID'.split(',')
+      dellist.each{|field| assert_nil(rec[field])}
+    end
+    test 'process a /var/log/messages record, default settings' do
+      ENV['IPADDR4'] = '127.0.0.1'
+      ENV['IPADDR6'] = '::1'
+      ENV['FLUENTD_VERSION'] = 'fversion'
+      ENV['DATA_VERSION'] = 'dversion'
+      now = Time.now
+      input = {"pid"=>12345,"ident"=>"service","host"=>"myhost","time"=>now,"message"=>"mymessage"}
+      rec = emit_with_tag('system.var.log.messages', input, '
+        <formatter>
+          tag "system.var.log**"
+          type sys_var_log
+          remove_keys host,pid,ident
+        </formatter>
+        pipeline_type normalizer
+      ')
+      assert_equal(12345, rec['systemd']['t']['PID'])
+      assert_equal("service", rec['systemd']['u']['SYSLOG_IDENTIFIER'])
+      assert_equal('mymessage', rec['message'])
+      assert_equal('myhost', rec['hostname'])
+      assert_equal(now.utc.to_datetime.rfc3339(6), rec['@timestamp'])
+      assert_equal('127.0.0.1', rec['pipeline_metadata']['normalizer']['ipaddr4'])
+      assert_equal('::1', rec['pipeline_metadata']['normalizer']['ipaddr6'])
+      assert_equal('fluent-plugin-systemd', rec['pipeline_metadata']['normalizer']['inputname'])
+      assert_equal('fluentd', rec['pipeline_metadata']['normalizer']['name'])
+      assert_equal('fversion dversion', rec['pipeline_metadata']['normalizer']['version'])
+      assert_equal(Time.at(@time).utc.to_datetime.rfc3339(6), rec['pipeline_metadata']['normalizer']['received_at'])
+      dellist = 'host,pid,ident'.split(',')
+      dellist.each{|field| assert_nil(rec[field])}
+    end
+    test 'process a /var/log/messages record, future date' do
+      ENV['IPADDR4'] = '127.0.0.1'
+      ENV['IPADDR6'] = '::1'
+      ENV['FLUENTD_VERSION'] = 'fversion'
+      ENV['DATA_VERSION'] = 'dversion'
+      now = DateTime.strptime('Dec 31 23:59:59', '%b %d %H:%M:%S').to_time.utc
+      # subtract 1 from year
+      expected = Time.new(now.year-1, now.month, now.day, now.hour, now.min, now.sec, now.utc_offset)
+      input = {"pid"=>12345,"ident"=>"service","host"=>"myhost","time"=>now,"message"=>"mymessage"}
+      rec = emit_with_tag('system.var.log.messages', input, '
+        <formatter>
+          tag "system.var.log**"
+          type sys_var_log
+          remove_keys host,pid,ident
+        </formatter>
+        pipeline_type normalizer
+      ')
+      assert_equal(12345, rec['systemd']['t']['PID'])
+      assert_equal("service", rec['systemd']['u']['SYSLOG_IDENTIFIER'])
+      assert_equal('mymessage', rec['message'])
+      assert_equal('myhost', rec['hostname'])
+      assert_equal(expected.utc.to_datetime.rfc3339(6), rec['@timestamp'])
+      assert_equal('127.0.0.1', rec['pipeline_metadata']['normalizer']['ipaddr4'])
+      assert_equal('::1', rec['pipeline_metadata']['normalizer']['ipaddr6'])
+      assert_equal('fluent-plugin-systemd', rec['pipeline_metadata']['normalizer']['inputname'])
+      assert_equal('fluentd', rec['pipeline_metadata']['normalizer']['name'])
+      assert_equal('fversion dversion', rec['pipeline_metadata']['normalizer']['version'])
+      assert_equal(Time.at(@time).utc.to_datetime.rfc3339(6), rec['pipeline_metadata']['normalizer']['received_at'])
+      dellist = 'host,pid,ident'.split(',')
+      dellist.each{|field| assert_nil(rec[field])}
+    end
+    test 'process a k8s json-file record, default settings' do
+      ENV['IPADDR4'] = '127.0.0.1'
+      ENV['IPADDR6'] = '::1'
+      ENV['FLUENTD_VERSION'] = 'fversion'
+      ENV['DATA_VERSION'] = 'dversion'
+      now = Time.now
+      input = {'kubernetes'=>{'host'=>'k8shost'},'stream'=>'stderr','time'=>now,'log'=>'mymessage'}
+      rec = emit_with_tag('kubernetes.var.log.containers.name.name_this_that_other_log', input, '
+        <formatter>
+          tag "kubernetes.var.log.containers**"
+          type k8s_json_file
+          remove_keys log,stream
+        </formatter>
+        pipeline_type normalizer
+      ')
+      assert_equal('mymessage', rec['message'])
+      assert_equal('k8shost', rec['hostname'])
+      assert_equal('err', rec['level'])
+      assert_equal(now.utc.to_datetime.rfc3339(6), rec['@timestamp'])
+      assert_equal('127.0.0.1', rec['pipeline_metadata']['normalizer']['ipaddr4'])
+      assert_equal('::1', rec['pipeline_metadata']['normalizer']['ipaddr6'])
+      assert_equal('fluent-plugin-systemd', rec['pipeline_metadata']['normalizer']['inputname'])
+      assert_equal('fluentd', rec['pipeline_metadata']['normalizer']['name'])
+      assert_equal('fversion dversion', rec['pipeline_metadata']['normalizer']['version'])
+      assert_equal(Time.at(@time).utc.to_datetime.rfc3339(6), rec['pipeline_metadata']['normalizer']['received_at'])
+      dellist = 'host,pid,ident'.split(',')
+      dellist.each{|field| assert_nil(rec[field])}
+    end
+    # tests for elasticsearch index functionality
+    test 'construct an operations index prefix' do
+      rec = emit_with_tag('journal.system', normal_input, '
+        <formatter>
+          tag "journal.system**"
+          type sys_journal
+          remove_keys log,stream,MESSAGE,_SOURCE_REALTIME_TIMESTAMP,__REALTIME_TIMESTAMP,CONTAINER_ID,CONTAINER_ID_FULL,CONTAINER_NAME,PRIORITY,_BOOT_ID,_CAP_EFFECTIVE,_CMDLINE,_COMM,_EXE,_GID,_HOSTNAME,_MACHINE_ID,_PID,_SELINUX_CONTEXT,_SYSTEMD_CGROUP,_SYSTEMD_SLICE,_SYSTEMD_UNIT,_TRANSPORT,_UID,_AUDIT_LOGINUID,_AUDIT_SESSION,_SYSTEMD_OWNER_UID,_SYSTEMD_SESSION,_SYSTEMD_USER_UNIT,CODE_FILE,CODE_FUNCTION,CODE_LINE,ERRNO,MESSAGE_ID,RESULT,UNIT,_KERNEL_DEVICE,_KERNEL_SUBSYSTEM,_UDEV_SYSNAME,_UDEV_DEVNODE,_UDEV_DEVLINK,SYSLOG_FACILITY,SYSLOG_IDENTIFIER,SYSLOG_PID
+        </formatter>
+        <formatter>
+          tag "kubernetes.journal.container**"
+          type k8s_journal
+          remove_keys log,stream,MESSAGE,_SOURCE_REALTIME_TIMESTAMP,__REALTIME_TIMESTAMP,CONTAINER_ID,CONTAINER_ID_FULL,CONTAINER_NAME,PRIORITY,_BOOT_ID,_CAP_EFFECTIVE,_CMDLINE,_COMM,_EXE,_GID,_HOSTNAME,_MACHINE_ID,_PID,_SELINUX_CONTEXT,_SYSTEMD_CGROUP,_SYSTEMD_SLICE,_SYSTEMD_UNIT,_TRANSPORT,_UID,_AUDIT_LOGINUID,_AUDIT_SESSION,_SYSTEMD_OWNER_UID,_SYSTEMD_SESSION,_SYSTEMD_USER_UNIT,CODE_FILE,CODE_FUNCTION,CODE_LINE,ERRNO,MESSAGE_ID,RESULT,UNIT,_KERNEL_DEVICE,_KERNEL_SUBSYSTEM,_UDEV_SYSNAME,_UDEV_DEVNODE,_UDEV_DEVLINK,SYSLOG_FACILITY,SYSLOG_IDENTIFIER,SYSLOG_PID
+        </formatter>
+        <elasticsearch_index_name>
+          tag "journal.system** system.var.log** **_default_** **_openshift_** **_openshift-infra_** mux.ops"
+          name_type operations_prefix
+        </elasticsearch_index_name>
+        <elasticsearch_index_name>
+          tag "**"
+          name_type project_prefix
+        </elasticsearch_index_name>
+      ')
+      assert_equal('.operations', rec['viaq_index_prefix'])
+    end
+    test 'construct an operations index prefix with named field' do
+      rec = emit_with_tag('journal.system', normal_input, '
+        <formatter>
+          tag "journal.system**"
+          type sys_journal
+          remove_keys log,stream,MESSAGE,_SOURCE_REALTIME_TIMESTAMP,__REALTIME_TIMESTAMP,CONTAINER_ID,CONTAINER_ID_FULL,CONTAINER_NAME,PRIORITY,_BOOT_ID,_CAP_EFFECTIVE,_CMDLINE,_COMM,_EXE,_GID,_HOSTNAME,_MACHINE_ID,_PID,_SELINUX_CONTEXT,_SYSTEMD_CGROUP,_SYSTEMD_SLICE,_SYSTEMD_UNIT,_TRANSPORT,_UID,_AUDIT_LOGINUID,_AUDIT_SESSION,_SYSTEMD_OWNER_UID,_SYSTEMD_SESSION,_SYSTEMD_USER_UNIT,CODE_FILE,CODE_FUNCTION,CODE_LINE,ERRNO,MESSAGE_ID,RESULT,UNIT,_KERNEL_DEVICE,_KERNEL_SUBSYSTEM,_UDEV_SYSNAME,_UDEV_DEVNODE,_UDEV_DEVLINK,SYSLOG_FACILITY,SYSLOG_IDENTIFIER,SYSLOG_PID
+        </formatter>
+        <formatter>
+          tag "kubernetes.journal.container**"
+          type k8s_journal
+          remove_keys log,stream,MESSAGE,_SOURCE_REALTIME_TIMESTAMP,__REALTIME_TIMESTAMP,CONTAINER_ID,CONTAINER_ID_FULL,CONTAINER_NAME,PRIORITY,_BOOT_ID,_CAP_EFFECTIVE,_CMDLINE,_COMM,_EXE,_GID,_HOSTNAME,_MACHINE_ID,_PID,_SELINUX_CONTEXT,_SYSTEMD_CGROUP,_SYSTEMD_SLICE,_SYSTEMD_UNIT,_TRANSPORT,_UID,_AUDIT_LOGINUID,_AUDIT_SESSION,_SYSTEMD_OWNER_UID,_SYSTEMD_SESSION,_SYSTEMD_USER_UNIT,CODE_FILE,CODE_FUNCTION,CODE_LINE,ERRNO,MESSAGE_ID,RESULT,UNIT,_KERNEL_DEVICE,_KERNEL_SUBSYSTEM,_UDEV_SYSNAME,_UDEV_DEVNODE,_UDEV_DEVLINK,SYSLOG_FACILITY,SYSLOG_IDENTIFIER,SYSLOG_PID
+        </formatter>
+        <elasticsearch_index_name>
+          tag "journal.system** system.var.log** **_default_** **_openshift_** **_openshift-infra_** mux.ops"
+          name_type operations_prefix
+        </elasticsearch_index_name>
+        <elasticsearch_index_name>
+          tag "**"
+          name_type project_prefix
+        </elasticsearch_index_name>
+        elasticsearch_index_prefix_field my_index_prefix
+      ')
+      assert_equal('.operations', rec['my_index_prefix'])
+    end
+    test 'construct an operations index name with named field' do
+      rec = emit_with_tag('journal.system', normal_input, '
+        <formatter>
+          tag "journal.system**"
+          type sys_journal
+          remove_keys log,stream,MESSAGE,_SOURCE_REALTIME_TIMESTAMP,__REALTIME_TIMESTAMP,CONTAINER_ID,CONTAINER_ID_FULL,CONTAINER_NAME,PRIORITY,_BOOT_ID,_CAP_EFFECTIVE,_CMDLINE,_COMM,_EXE,_GID,_HOSTNAME,_MACHINE_ID,_PID,_SELINUX_CONTEXT,_SYSTEMD_CGROUP,_SYSTEMD_SLICE,_SYSTEMD_UNIT,_TRANSPORT,_UID,_AUDIT_LOGINUID,_AUDIT_SESSION,_SYSTEMD_OWNER_UID,_SYSTEMD_SESSION,_SYSTEMD_USER_UNIT,CODE_FILE,CODE_FUNCTION,CODE_LINE,ERRNO,MESSAGE_ID,RESULT,UNIT,_KERNEL_DEVICE,_KERNEL_SUBSYSTEM,_UDEV_SYSNAME,_UDEV_DEVNODE,_UDEV_DEVLINK,SYSLOG_FACILITY,SYSLOG_IDENTIFIER,SYSLOG_PID
+        </formatter>
+        <formatter>
+          tag "kubernetes.journal.container**"
+          type k8s_journal
+          remove_keys log,stream,MESSAGE,_SOURCE_REALTIME_TIMESTAMP,__REALTIME_TIMESTAMP,CONTAINER_ID,CONTAINER_ID_FULL,CONTAINER_NAME,PRIORITY,_BOOT_ID,_CAP_EFFECTIVE,_CMDLINE,_COMM,_EXE,_GID,_HOSTNAME,_MACHINE_ID,_PID,_SELINUX_CONTEXT,_SYSTEMD_CGROUP,_SYSTEMD_SLICE,_SYSTEMD_UNIT,_TRANSPORT,_UID,_AUDIT_LOGINUID,_AUDIT_SESSION,_SYSTEMD_OWNER_UID,_SYSTEMD_SESSION,_SYSTEMD_USER_UNIT,CODE_FILE,CODE_FUNCTION,CODE_LINE,ERRNO,MESSAGE_ID,RESULT,UNIT,_KERNEL_DEVICE,_KERNEL_SUBSYSTEM,_UDEV_SYSNAME,_UDEV_DEVNODE,_UDEV_DEVLINK,SYSLOG_FACILITY,SYSLOG_IDENTIFIER,SYSLOG_PID
+        </formatter>
+        <elasticsearch_index_name>
+          tag "journal.system** system.var.log** **_default_** **_openshift_** **_openshift-infra_** mux.ops"
+          name_type operations_full
+        </elasticsearch_index_name>
+        <elasticsearch_index_name>
+          tag "**"
+          name_type project_full
+        </elasticsearch_index_name>
+        elasticsearch_index_name_field my_index_name
+      ')
+      assert_equal('.operations.2017.07.27', rec['my_index_name'])
+    end
+    test 'log error if missing kubernetes field' do
+      rec = emit_with_tag('kubernetes.journal.container.something', normal_input, '
+        <formatter>
+          tag "journal.system**"
+          type sys_journal
+          remove_keys log,stream,MESSAGE,_SOURCE_REALTIME_TIMESTAMP,__REALTIME_TIMESTAMP,CONTAINER_ID,CONTAINER_ID_FULL,CONTAINER_NAME,PRIORITY,_BOOT_ID,_CAP_EFFECTIVE,_CMDLINE,_COMM,_EXE,_GID,_HOSTNAME,_MACHINE_ID,_PID,_SELINUX_CONTEXT,_SYSTEMD_CGROUP,_SYSTEMD_SLICE,_SYSTEMD_UNIT,_TRANSPORT,_UID,_AUDIT_LOGINUID,_AUDIT_SESSION,_SYSTEMD_OWNER_UID,_SYSTEMD_SESSION,_SYSTEMD_USER_UNIT,CODE_FILE,CODE_FUNCTION,CODE_LINE,ERRNO,MESSAGE_ID,RESULT,UNIT,_KERNEL_DEVICE,_KERNEL_SUBSYSTEM,_UDEV_SYSNAME,_UDEV_DEVNODE,_UDEV_DEVLINK,SYSLOG_FACILITY,SYSLOG_IDENTIFIER,SYSLOG_PID
+        </formatter>
+        <formatter>
+          tag "kubernetes.journal.container**"
+          type k8s_journal
+          remove_keys log,stream,MESSAGE,_SOURCE_REALTIME_TIMESTAMP,__REALTIME_TIMESTAMP,CONTAINER_ID,CONTAINER_ID_FULL,CONTAINER_NAME,PRIORITY,_BOOT_ID,_CAP_EFFECTIVE,_CMDLINE,_COMM,_EXE,_GID,_HOSTNAME,_MACHINE_ID,_PID,_SELINUX_CONTEXT,_SYSTEMD_CGROUP,_SYSTEMD_SLICE,_SYSTEMD_UNIT,_TRANSPORT,_UID,_AUDIT_LOGINUID,_AUDIT_SESSION,_SYSTEMD_OWNER_UID,_SYSTEMD_SESSION,_SYSTEMD_USER_UNIT,CODE_FILE,CODE_FUNCTION,CODE_LINE,ERRNO,MESSAGE_ID,RESULT,UNIT,_KERNEL_DEVICE,_KERNEL_SUBSYSTEM,_UDEV_SYSNAME,_UDEV_DEVNODE,_UDEV_DEVLINK,SYSLOG_FACILITY,SYSLOG_IDENTIFIER,SYSLOG_PID
+        </formatter>
+        <elasticsearch_index_name>
+          tag "journal.system** system.var.log** **_default_** **_openshift_** **_openshift-infra_** mux.ops"
+          name_type operations_prefix
+        </elasticsearch_index_name>
+        <elasticsearch_index_name>
+          tag "**"
+          name_type project_prefix
+        </elasticsearch_index_name>
+      ')
+      assert_match /record is missing kubernetes field/, @dlog.logs[0]
+    end
+    test 'log error if missing kubernetes.namespace_name field' do
+      input = normal_input.merge({})
+      input['kubernetes'] = 'junk'
+      rec = emit_with_tag('kubernetes.journal.container.something', input, '
+        <formatter>
+          tag "journal.system**"
+          type sys_journal
+          remove_keys log,stream,MESSAGE,_SOURCE_REALTIME_TIMESTAMP,__REALTIME_TIMESTAMP,CONTAINER_ID,CONTAINER_ID_FULL,CONTAINER_NAME,PRIORITY,_BOOT_ID,_CAP_EFFECTIVE,_CMDLINE,_COMM,_EXE,_GID,_HOSTNAME,_MACHINE_ID,_PID,_SELINUX_CONTEXT,_SYSTEMD_CGROUP,_SYSTEMD_SLICE,_SYSTEMD_UNIT,_TRANSPORT,_UID,_AUDIT_LOGINUID,_AUDIT_SESSION,_SYSTEMD_OWNER_UID,_SYSTEMD_SESSION,_SYSTEMD_USER_UNIT,CODE_FILE,CODE_FUNCTION,CODE_LINE,ERRNO,MESSAGE_ID,RESULT,UNIT,_KERNEL_DEVICE,_KERNEL_SUBSYSTEM,_UDEV_SYSNAME,_UDEV_DEVNODE,_UDEV_DEVLINK,SYSLOG_FACILITY,SYSLOG_IDENTIFIER,SYSLOG_PID
+        </formatter>
+        <formatter>
+          tag "kubernetes.journal.container**"
+          type k8s_journal
+          remove_keys log,stream,MESSAGE,_SOURCE_REALTIME_TIMESTAMP,__REALTIME_TIMESTAMP,CONTAINER_ID,CONTAINER_ID_FULL,CONTAINER_NAME,PRIORITY,_BOOT_ID,_CAP_EFFECTIVE,_CMDLINE,_COMM,_EXE,_GID,_HOSTNAME,_MACHINE_ID,_PID,_SELINUX_CONTEXT,_SYSTEMD_CGROUP,_SYSTEMD_SLICE,_SYSTEMD_UNIT,_TRANSPORT,_UID,_AUDIT_LOGINUID,_AUDIT_SESSION,_SYSTEMD_OWNER_UID,_SYSTEMD_SESSION,_SYSTEMD_USER_UNIT,CODE_FILE,CODE_FUNCTION,CODE_LINE,ERRNO,MESSAGE_ID,RESULT,UNIT,_KERNEL_DEVICE,_KERNEL_SUBSYSTEM,_UDEV_SYSNAME,_UDEV_DEVNODE,_UDEV_DEVLINK,SYSLOG_FACILITY,SYSLOG_IDENTIFIER,SYSLOG_PID
+        </formatter>
+        <elasticsearch_index_name>
+          tag "journal.system** system.var.log** **_default_** **_openshift_** **_openshift-infra_** mux.ops"
+          name_type operations_prefix
+        </elasticsearch_index_name>
+        <elasticsearch_index_name>
+          tag "**"
+          name_type project_prefix
+        </elasticsearch_index_name>
+      ')
+      assert_match /record is missing kubernetes.namespace_name field/, @dlog.logs[0]
+    end
+    test 'log error if missing kubernetes.namespace_id field' do
+      input = normal_input.merge({})
+      input['kubernetes'] = {'namespace_name'=>'junk'}
+      rec = emit_with_tag('kubernetes.journal.container.something', input, '
+        <formatter>
+          tag "journal.system**"
+          type sys_journal
+          remove_keys log,stream,MESSAGE,_SOURCE_REALTIME_TIMESTAMP,__REALTIME_TIMESTAMP,CONTAINER_ID,CONTAINER_ID_FULL,CONTAINER_NAME,PRIORITY,_BOOT_ID,_CAP_EFFECTIVE,_CMDLINE,_COMM,_EXE,_GID,_HOSTNAME,_MACHINE_ID,_PID,_SELINUX_CONTEXT,_SYSTEMD_CGROUP,_SYSTEMD_SLICE,_SYSTEMD_UNIT,_TRANSPORT,_UID,_AUDIT_LOGINUID,_AUDIT_SESSION,_SYSTEMD_OWNER_UID,_SYSTEMD_SESSION,_SYSTEMD_USER_UNIT,CODE_FILE,CODE_FUNCTION,CODE_LINE,ERRNO,MESSAGE_ID,RESULT,UNIT,_KERNEL_DEVICE,_KERNEL_SUBSYSTEM,_UDEV_SYSNAME,_UDEV_DEVNODE,_UDEV_DEVLINK,SYSLOG_FACILITY,SYSLOG_IDENTIFIER,SYSLOG_PID
+        </formatter>
+        <formatter>
+          tag "kubernetes.journal.container**"
+          type k8s_journal
+          remove_keys log,stream,MESSAGE,_SOURCE_REALTIME_TIMESTAMP,__REALTIME_TIMESTAMP,CONTAINER_ID,CONTAINER_ID_FULL,CONTAINER_NAME,PRIORITY,_BOOT_ID,_CAP_EFFECTIVE,_CMDLINE,_COMM,_EXE,_GID,_HOSTNAME,_MACHINE_ID,_PID,_SELINUX_CONTEXT,_SYSTEMD_CGROUP,_SYSTEMD_SLICE,_SYSTEMD_UNIT,_TRANSPORT,_UID,_AUDIT_LOGINUID,_AUDIT_SESSION,_SYSTEMD_OWNER_UID,_SYSTEMD_SESSION,_SYSTEMD_USER_UNIT,CODE_FILE,CODE_FUNCTION,CODE_LINE,ERRNO,MESSAGE_ID,RESULT,UNIT,_KERNEL_DEVICE,_KERNEL_SUBSYSTEM,_UDEV_SYSNAME,_UDEV_DEVNODE,_UDEV_DEVLINK,SYSLOG_FACILITY,SYSLOG_IDENTIFIER,SYSLOG_PID
+        </formatter>
+        <elasticsearch_index_name>
+          tag "journal.system** system.var.log** **_default_** **_openshift_** **_openshift-infra_** mux.ops"
+          name_type operations_prefix
+        </elasticsearch_index_name>
+        <elasticsearch_index_name>
+          tag "**"
+          name_type project_prefix
+        </elasticsearch_index_name>
+      ')
+      assert_match /record is missing kubernetes.namespace_id field/, @dlog.logs[0]
+    end
+    test 'construct a kubernetes index prefix' do
+      input = normal_input.merge({})
+      input['kubernetes'] = {'namespace_name'=>'name', 'namespace_id'=>'uuid'}
+      rec = emit_with_tag('kubernetes.journal.container.something', input, '
+        <formatter>
+          tag "journal.system**"
+          type sys_journal
+          remove_keys log,stream,MESSAGE,_SOURCE_REALTIME_TIMESTAMP,__REALTIME_TIMESTAMP,CONTAINER_ID,CONTAINER_ID_FULL,CONTAINER_NAME,PRIORITY,_BOOT_ID,_CAP_EFFECTIVE,_CMDLINE,_COMM,_EXE,_GID,_HOSTNAME,_MACHINE_ID,_PID,_SELINUX_CONTEXT,_SYSTEMD_CGROUP,_SYSTEMD_SLICE,_SYSTEMD_UNIT,_TRANSPORT,_UID,_AUDIT_LOGINUID,_AUDIT_SESSION,_SYSTEMD_OWNER_UID,_SYSTEMD_SESSION,_SYSTEMD_USER_UNIT,CODE_FILE,CODE_FUNCTION,CODE_LINE,ERRNO,MESSAGE_ID,RESULT,UNIT,_KERNEL_DEVICE,_KERNEL_SUBSYSTEM,_UDEV_SYSNAME,_UDEV_DEVNODE,_UDEV_DEVLINK,SYSLOG_FACILITY,SYSLOG_IDENTIFIER,SYSLOG_PID
+        </formatter>
+        <formatter>
+          tag "kubernetes.journal.container**"
+          type k8s_journal
+          remove_keys log,stream,MESSAGE,_SOURCE_REALTIME_TIMESTAMP,__REALTIME_TIMESTAMP,CONTAINER_ID,CONTAINER_ID_FULL,CONTAINER_NAME,PRIORITY,_BOOT_ID,_CAP_EFFECTIVE,_CMDLINE,_COMM,_EXE,_GID,_HOSTNAME,_MACHINE_ID,_PID,_SELINUX_CONTEXT,_SYSTEMD_CGROUP,_SYSTEMD_SLICE,_SYSTEMD_UNIT,_TRANSPORT,_UID,_AUDIT_LOGINUID,_AUDIT_SESSION,_SYSTEMD_OWNER_UID,_SYSTEMD_SESSION,_SYSTEMD_USER_UNIT,CODE_FILE,CODE_FUNCTION,CODE_LINE,ERRNO,MESSAGE_ID,RESULT,UNIT,_KERNEL_DEVICE,_KERNEL_SUBSYSTEM,_UDEV_SYSNAME,_UDEV_DEVNODE,_UDEV_DEVLINK,SYSLOG_FACILITY,SYSLOG_IDENTIFIER,SYSLOG_PID
+        </formatter>
+        <elasticsearch_index_name>
+          tag "journal.system** system.var.log** **_default_** **_openshift_** **_openshift-infra_** mux.ops"
+          name_type operations_prefix
+        </elasticsearch_index_name>
+        <elasticsearch_index_name>
+          tag "**"
+          name_type project_prefix
+        </elasticsearch_index_name>
+      ')
+      assert_equal('project.name.uuid', rec['viaq_index_prefix'])
+    end
+    test 'construct a kubernetes index prefix with named field' do
+      input = normal_input.merge({})
+      input['kubernetes'] = {'namespace_name'=>'name', 'namespace_id'=>'uuid'}
+      rec = emit_with_tag('kubernetes.journal.container.something', input, '
+        <formatter>
+          tag "journal.system**"
+          type sys_journal
+          remove_keys log,stream,MESSAGE,_SOURCE_REALTIME_TIMESTAMP,__REALTIME_TIMESTAMP,CONTAINER_ID,CONTAINER_ID_FULL,CONTAINER_NAME,PRIORITY,_BOOT_ID,_CAP_EFFECTIVE,_CMDLINE,_COMM,_EXE,_GID,_HOSTNAME,_MACHINE_ID,_PID,_SELINUX_CONTEXT,_SYSTEMD_CGROUP,_SYSTEMD_SLICE,_SYSTEMD_UNIT,_TRANSPORT,_UID,_AUDIT_LOGINUID,_AUDIT_SESSION,_SYSTEMD_OWNER_UID,_SYSTEMD_SESSION,_SYSTEMD_USER_UNIT,CODE_FILE,CODE_FUNCTION,CODE_LINE,ERRNO,MESSAGE_ID,RESULT,UNIT,_KERNEL_DEVICE,_KERNEL_SUBSYSTEM,_UDEV_SYSNAME,_UDEV_DEVNODE,_UDEV_DEVLINK,SYSLOG_FACILITY,SYSLOG_IDENTIFIER,SYSLOG_PID
+        </formatter>
+        <formatter>
+          tag "kubernetes.journal.container**"
+          type k8s_journal
+          remove_keys log,stream,MESSAGE,_SOURCE_REALTIME_TIMESTAMP,__REALTIME_TIMESTAMP,CONTAINER_ID,CONTAINER_ID_FULL,CONTAINER_NAME,PRIORITY,_BOOT_ID,_CAP_EFFECTIVE,_CMDLINE,_COMM,_EXE,_GID,_HOSTNAME,_MACHINE_ID,_PID,_SELINUX_CONTEXT,_SYSTEMD_CGROUP,_SYSTEMD_SLICE,_SYSTEMD_UNIT,_TRANSPORT,_UID,_AUDIT_LOGINUID,_AUDIT_SESSION,_SYSTEMD_OWNER_UID,_SYSTEMD_SESSION,_SYSTEMD_USER_UNIT,CODE_FILE,CODE_FUNCTION,CODE_LINE,ERRNO,MESSAGE_ID,RESULT,UNIT,_KERNEL_DEVICE,_KERNEL_SUBSYSTEM,_UDEV_SYSNAME,_UDEV_DEVNODE,_UDEV_DEVLINK,SYSLOG_FACILITY,SYSLOG_IDENTIFIER,SYSLOG_PID
+        </formatter>
+        <elasticsearch_index_name>
+          tag "journal.system** system.var.log** **_default_** **_openshift_** **_openshift-infra_** mux.ops"
+          name_type operations_prefix
+        </elasticsearch_index_name>
+        <elasticsearch_index_name>
+          tag "**"
+          name_type project_prefix
+        </elasticsearch_index_name>
+        elasticsearch_index_prefix_field my_index_prefix
+      ')
+      assert_equal('project.name.uuid', rec['my_index_prefix'])
+    end
+    test 'construct a kubernetes index name with named field' do
+      input = normal_input.merge({})
+      input['kubernetes'] = {'namespace_name'=>'name', 'namespace_id'=>'uuid'}
+      rec = emit_with_tag('kubernetes.journal.container.something', input, '
+        <formatter>
+          tag "journal.system**"
+          type sys_journal
+          remove_keys log,stream,MESSAGE,_SOURCE_REALTIME_TIMESTAMP,__REALTIME_TIMESTAMP,CONTAINER_ID,CONTAINER_ID_FULL,CONTAINER_NAME,PRIORITY,_BOOT_ID,_CAP_EFFECTIVE,_CMDLINE,_COMM,_EXE,_GID,_HOSTNAME,_MACHINE_ID,_PID,_SELINUX_CONTEXT,_SYSTEMD_CGROUP,_SYSTEMD_SLICE,_SYSTEMD_UNIT,_TRANSPORT,_UID,_AUDIT_LOGINUID,_AUDIT_SESSION,_SYSTEMD_OWNER_UID,_SYSTEMD_SESSION,_SYSTEMD_USER_UNIT,CODE_FILE,CODE_FUNCTION,CODE_LINE,ERRNO,MESSAGE_ID,RESULT,UNIT,_KERNEL_DEVICE,_KERNEL_SUBSYSTEM,_UDEV_SYSNAME,_UDEV_DEVNODE,_UDEV_DEVLINK,SYSLOG_FACILITY,SYSLOG_IDENTIFIER,SYSLOG_PID
+        </formatter>
+        <formatter>
+          tag "kubernetes.journal.container**"
+          type k8s_journal
+          remove_keys log,stream,MESSAGE,_SOURCE_REALTIME_TIMESTAMP,__REALTIME_TIMESTAMP,CONTAINER_ID,CONTAINER_ID_FULL,CONTAINER_NAME,PRIORITY,_BOOT_ID,_CAP_EFFECTIVE,_CMDLINE,_COMM,_EXE,_GID,_HOSTNAME,_MACHINE_ID,_PID,_SELINUX_CONTEXT,_SYSTEMD_CGROUP,_SYSTEMD_SLICE,_SYSTEMD_UNIT,_TRANSPORT,_UID,_AUDIT_LOGINUID,_AUDIT_SESSION,_SYSTEMD_OWNER_UID,_SYSTEMD_SESSION,_SYSTEMD_USER_UNIT,CODE_FILE,CODE_FUNCTION,CODE_LINE,ERRNO,MESSAGE_ID,RESULT,UNIT,_KERNEL_DEVICE,_KERNEL_SUBSYSTEM,_UDEV_SYSNAME,_UDEV_DEVNODE,_UDEV_DEVLINK,SYSLOG_FACILITY,SYSLOG_IDENTIFIER,SYSLOG_PID
+        </formatter>
+        <elasticsearch_index_name>
+          tag "journal.system** system.var.log** **_default_** **_openshift_** **_openshift-infra_** mux.ops"
+          name_type operations_full
+        </elasticsearch_index_name>
+        <elasticsearch_index_name>
+          tag "**"
+          name_type project_full
+        </elasticsearch_index_name>
+        elasticsearch_index_name_field my_index_name
+      ')
+      assert_equal('project.name.uuid.2017.07.27', rec['my_index_name'])
+    end
   end
 end


### PR DESCRIPTION
This allows the viaq filter to be used to convert systemd journal
records read in by the systemd journal input.  This also allows
the viaq filter to construct Elasticsearch index names for
openshift/origin-aggregated-logging for the operations and
kubernetes indices.