### PR TITLE
[WIP] event transformations

### DIFF
--- a/lib/fluent/plugin/filter_viaq_data_model_systemd.rb
+++ b/lib/fluent/plugin/filter_viaq_data_model_systemd.rb
@@ -129,6 +129,7 @@ module ViaqDataModelFilterSystemd
       else
         record['hostname'] = record['_HOSTNAME']
       end
+      transform_eventrouter(tag, record)
     end
   end
 end


### PR DESCRIPTION
Initial implementation of event transformations of logs from the eventrouter, configurable by setting proper formatter (`k8s_json_file` or `k8s_journal`)

Example:
```
<filter **>
  @type viaq_data_model
  ..
  <formatter>
    type k8s_journal
    tag "kubernetes.**"
  </formatter>
  ..
</filter>
```

There is an optional argument to keep both formatters working without transforming event logs:
```
process_kubernetes_events   false
```

Transforms following fields:
```
kubernetes.event                                 <- event
pipeline_metadata.collector.original_raw_message <- message
message                                          <- event.message
@dest_time_name                                  <- event.metadata.creationTimestamp
```

cc: @richm , @portante 