### PR TITLE
Fix json file time handling

### DIFF
--- a/fluent-plugin-viaq_data_model.gemspec
+++ b/fluent-plugin-viaq_data_model.gemspec
@@ -7,7 +7,7 @@ FLUENTD_VERSION = ENV['FLUENTD_VERSION'] || "0.12.0"
 
 Gem::Specification.new do |gem|
   gem.name          = "fluent-plugin-viaq_data_model"
-  gem.version       = "0.0.8"
+  gem.version       = "0.0.9"
   gem.authors       = ["Rich Megginson"]
   gem.email         = ["rmeggins@redhat.com"]
   gem.description   = %q{Filter plugin to ensure data is in the ViaQ common data model}

--- a/lib/fluent/plugin/filter_viaq_data_model_systemd.rb
+++ b/lib/fluent/plugin/filter_viaq_data_model_systemd.rb
@@ -68,19 +68,19 @@ module ViaqDataModelFilterSystemd
   def process_journal_fields(tag, time, record, fmtr_type)
     systemd_t = {}
     JOURNAL_FIELD_MAP_SYSTEMD_T.each do |jkey, key|
-      if record[jkey]
+      if record.key?(jkey)
         systemd_t[key] = record[jkey]
       end
     end
     systemd_u = {}
     JOURNAL_FIELD_MAP_SYSTEMD_U.each do |jkey, key|
-      if record[jkey]
+      if record.key?(jkey)
         systemd_u[key] = record[jkey]
       end
     end
     systemd_k = {}
     JOURNAL_FIELD_MAP_SYSTEMD_K.each do |jkey, key|
-      if record[jkey]
+      if record.key?(jkey)
         systemd_k[key] = record[jkey]
       end
     end
@@ -106,8 +106,8 @@ module ViaqDataModelFilterSystemd
     end
     record['level'] = ["emerg", "alert", "crit", "err", "warning", "notice", "info", "debug", "trace", "unknown"][pri_index]
     JOURNAL_TIME_FIELDS.each do |field|
-      if record[field]
-        record['time'] = Time.at(record[field].to_f / 1000000.0).utc.to_datetime.rfc3339(6)
+      if (val = record[field])
+        record['time'] = Time.at(val.to_f / 1000000.0).utc.to_datetime.rfc3339(6)
         break
       end
     end
@@ -121,8 +121,9 @@ module ViaqDataModelFilterSystemd
       end
     when :k8s_journal
       record['message'] = record['message'] || record['MESSAGE'] || record['log']
-      if record['kubernetes'] && record['kubernetes']['host']
-        record['hostname'] = record['kubernetes']['host']
+      if record.key?('kubernetes') && record['kubernetes'].respond_to?(:fetch) && \
+         (k8shost = record['kubernetes'].fetch('host', nil))
+        record['hostname'] = k8shost
       elsif @docker_hostname
         record['hostname'] = @docker_hostname
       else


### PR DESCRIPTION
Improve time handling.  In the `/var/log/messages` case and the k8s json-file log case, the `record['time']` field is a String and the `time` parameter to the filter is unix `time_t` format.  Make sure these are handled and parsed correctly.  Note that in the k8s json-file log case, there may be no `time` field at all, depending on the way the JSON embedded in the message is parsed.
Also use `has_key?` in a few places where the value is not needed.