### PR TITLE
Bug 1514110 - Aggregated Logging replacing all log levels with '3' an…

### DIFF
--- a/lib/fluent/plugin/filter_viaq_data_model_systemd.rb
+++ b/lib/fluent/plugin/filter_viaq_data_model_systemd.rb
@@ -93,18 +93,7 @@ module ViaqDataModelFilterSystemd
     unless systemd_k.empty?
       (record['systemd'] ||= {})['k'] = systemd_k
     end
-    begin
-      pri_index = ('%d' % record['PRIORITY'] || 9).to_i
-      case
-      when pri_index < 0
-        pri_index = 9
-      when pri_index > 9
-        pri_index = 9
-      end
-    rescue
-      pri_index = 9
-    end
-    record['level'] = ["emerg", "alert", "crit", "err", "warning", "notice", "info", "debug", "trace", "unknown"][pri_index]
+    record['level'] = normalize_level(record['level'], nil, nil, record['PRIORITY'])
     JOURNAL_TIME_FIELDS.each do |field|
       if (val = record[field])
         vali = val.to_i


### PR DESCRIPTION
…d '6' after upgrade to 3.5 from 3.4

https://bugzilla.redhat.com/show_bug.cgi?id=1514110
If there is already a `level` field in the record, then see if it is
a "close" match to one of the canonical `level` field values at
https://github.com/ViaQ/elasticsearch-templates/blob/master/namespaces/_default_.yml#L63
e.g. if `level` is "CRITICAL", convert to "crit", if level
is "WARN" convert to 'warning', etc.

Otherwise, if we cannot use it directly or normalize it, convert
it to its string representation (ruby `to_s` method) and store
the string value in the `level` field.

This commit cleans up other `level` processing and adds several tests
for `level` processing.