### PR TITLE
Bug 1588772 - After upgrade to 3.6 some logs are not showing in the K…

### DIFF
--- a/lib/fluent/plugin/filter_viaq_data_model.rb
+++ b/lib/fluent/plugin/filter_viaq_data_model.rb
@@ -435,7 +435,7 @@ module Fluent
 
     def transform_eventrouter(tag, record)
       return unless @process_kubernetes_events
-      if record.key?("event")
+      if record.key?("event") && record["event"].respond_to?(:key?)
         if record.key?("verb")
           record["event"]["verb"] = record.delete("verb")
         end


### PR DESCRIPTION
…ibana webUI

https://bugzilla.redhat.com/show_bug.cgi?id=1588772

Cause: The incoming data has a field `record["event"]` that
is a String value and not the Hash value expected by the
transform_eventrouter code.

Consequence: This causes the code to throw an error and fluentd
to emit an error like this:
```
error_class=NoMethodError error="undefined method `key?' for \"request\":String"
```
Fix: The transform_eventrouter code has been changed to only
process the `record["event"]` field if it is a Hash.

Result: Records can flow through to the destination again.