### PR TITLE
Use lastTimestamp instead of creationTimestamp

### DIFF
--- a/lib/fluent/plugin/filter_viaq_data_model.rb
+++ b/lib/fluent/plugin/filter_viaq_data_model.rb
@@ -83,7 +83,7 @@ module Fluent
     DOT_REPLACE_CHAR_UNUSED = 'UNUSED'
     desc 'Undefined dot replace char - highly recommended to use _'
     config_param :undefined_dot_replace_char, :string, default: DOT_REPLACE_CHAR_UNUSED
-  
+
     NUM_FIELDS_UNLIMITED = -1
     desc 'Maximum number of undefined fields - highly recommended to use 500 or less'
     config_param :undefined_max_num_fields, :integer, default: NUM_FIELDS_UNLIMITED
@@ -458,7 +458,7 @@ module Fluent
           ((record['pipeline_metadata'] ||= {})[@pipeline_type.to_s] ||= {})['original_raw_message'] = record['message']
         end
         record['message'] = record["kubernetes"]["event"].delete("message")
-        record['time'] = record["kubernetes"]["event"]["metadata"].delete("creationTimestamp") 
+        record['time'] = record["kubernetes"]["event"]["metadata"].delete("lastTimestamp")
       end
     end
 


### PR DESCRIPTION
This resolves issue ViaQ/fluent-plugin-viaq_data_model#18. 

Basically we are seeing issues where there are log entries that have a `creationTimestamp`, which is the date and time that the error was first generated by the kubernetes pod, and there is the `lastTimestamp`, which is the current date and time of that particular message. We need the `lastTimestamp` message to be used for this field, not the date from days or weeks ago, because that causes the log message to not appear for the correct day.

If there's a better way to accomplish this than a code change, I welcome any suggestions. 🙂