### PR TITLE
Bug 1746968: Remove hostpath mount /etc/hostname and pass via env var

### DIFF
--- a/lib/fluent/plugin/filter_viaq_data_model.rb
+++ b/lib/fluent/plugin/filter_viaq_data_model.rb
@@ -200,7 +200,7 @@ module Fluent
       begin
         @docker_hostname = File.open('/etc/docker-hostname') { |f| f.readline }.rstrip
       rescue
-        @docker_hostname = nil
+        @docker_hostname = ENV['NODE_NAME'] || nil
       end
       @ipaddr4 = ENV['IPADDR4'] || '127.0.0.1'
       @ipaddr6 = nil


### PR DESCRIPTION
Use NODE_NAME if available and /etc/docker-hostname is not