### PR TITLE
Bug 1756920: fluentd pods do not process kubernetes events

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,13 @@ See `filter-viaq_data_model.conf` for an example filter configuration.
 * `keep_empty_fields` - comma delimited string - default `''`
   * Always keep these top level fields, even if they are empty
   * `keep_empty_fields message` - keep the `message` field, even if empty
+* `process_kubernetes_events` - boolean - default `true`
+  * If a record looks like a kubernetes event that has been added by the
+  * eventrouter, add its fields under `kubernetes.event`
+  * A record is considered to be a kubernetes eventrouter event if the
+  * record has a top level field called `event` and it is a Hash.  If you
+  * are not sure if this is always true, then define a specific tag or tags
+  * and use a per-formatter `process_kubernetes_events` setting, below
 * `use_undefined` - boolean - default `false`
   * If `true`, move fields not specified in `default_keep_fields` and
   `extra_keep_fields` to the `undefined` top level field.  If you use
@@ -140,8 +147,16 @@ See `filter-viaq_data_model.conf` for an example filter configuration.
     * `sys_var_log` - a record read from `/var/log/messages`
     * `k8s_json_file` - a record read from a `/var/log/containers/*.log` JSON
       formatted container log file
-    * `tag` - the Fluentd tag pattern to match for these records
-    * `remove_keys` - comma delimited list of keys to remove from the record
+  * `tag` - the Fluentd tag pattern to match for these records
+  * `remove_keys` - comma delimited list of keys to remove from the record
+  * `process_kubernetes_events` - boolean - defaults to the global setting above
+    * If a record looks like a kubernetes event that has been added by the
+    * eventrouter, add its fields under `kubernetes.event`
+    * A record is considered to be a kubernetes eventrouter event if the
+    * record has a top level field called `event` and it is a Hash.
+    * This per-formatter setting will override the global setting (see above)
+    * This allows you to set the global setting to `false`, then only process
+    * kubernetes events for this formatter matching this set of `tag` patterns.
 * `pipeline_type` - which part of the pipeline is this? `collector` or
   `normalizer` - the default is `collector`
 * `elasticsearch_index_name` - how to construct Elasticsearch index names or

--- a/lib/fluent/plugin/filter_viaq_data_model.rb
+++ b/lib/fluent/plugin/filter_viaq_data_model.rb
@@ -119,6 +119,8 @@ module Fluent
       config_param :tag, :string
       desc 'remove these keys from the record - same as record_transformer "remove_keys" field'
       config_param :remove_keys, :string, default: nil
+      desc 'enable/disable processing of kubernetes events'
+      config_param :process_kubernetes_events, :bool, default: nil
     end
 
     desc 'Which part of the pipeline is this - collector, normalizer, etc. for pipeline_metadata'
@@ -178,7 +180,6 @@ module Fluent
         @formatters.each do |fmtr|
           matcher = ViaqMatchClass.new(fmtr.tag, nil)
           fmtr.instance_eval{ @params[:matcher] = matcher }
-          fmtr.instance_eval{ @params[:fmtr_type] = fmtr.type }
           if fmtr.remove_keys
             fmtr.instance_eval{ @params[:fmtr_remove_keys] = fmtr.remove_keys.split(',') }
           else
@@ -193,6 +194,8 @@ module Fluent
             fmtr_func = method(:process_k8s_json_file_fields)
           end
           fmtr.instance_eval{ @params[:fmtr_func] = fmtr_func }
+          proc_k8s_ev = fmtr.process_kubernetes_events.nil? ? @process_kubernetes_events : fmtr.process_kubernetes_events
+          fmtr.instance_eval{ @params[:process_kubernetes_events] = proc_k8s_ev }
         end
         @formatter_cache = {}
         @formatter_cache_nomatch = {}
@@ -303,7 +306,7 @@ module Fluent
       retlevel || 'unknown'
     end
 
-    def process_sys_var_log_fields(tag, time, record, fmtr_type = nil)
+    def process_sys_var_log_fields(tag, time, record, fmtr = nil)
       record['systemd'] = {"t" => {"PID" => record['pid']}, "u" => {"SYSLOG_IDENTIFIER" => record['ident']}}
       if record[@dest_time_name].nil? # e.g. already has @timestamp
         # handle the case where the time reported in /var/log/messages is for a previous year
@@ -320,7 +323,7 @@ module Fluent
       end
     end
 
-    def process_k8s_json_file_fields(tag, time, record, fmtr_type = nil)
+    def process_k8s_json_file_fields(tag, time, record, fmtr = nil)
       record['message'] = record['message'] || record['log']
       record['level'] = normalize_level(record['level'], nil)
       if record.key?('kubernetes') && record['kubernetes'].respond_to?(:fetch) && \
@@ -339,7 +342,7 @@ module Fluent
         end
         record['time'] = rectime.utc.to_datetime.rfc3339(6)
       end
-      transform_eventrouter(tag, record)
+      transform_eventrouter(tag, record, fmtr)
     end
 
     def check_for_match_and_format(tag, time, record)
@@ -355,7 +358,7 @@ module Fluent
           return
         end
       end
-      fmtr.fmtr_func.call(tag, time, record, fmtr.fmtr_type)
+      fmtr.fmtr_func.call(tag, time, record, fmtr)
 
       if record[@dest_time_name].nil? && record['time'].nil?
         record['time'] = Time.at(time).utc.to_datetime.rfc3339(6)
@@ -449,8 +452,8 @@ module Fluent
       end
     end
 
-    def transform_eventrouter(tag, record)
-      return unless @process_kubernetes_events
+    def transform_eventrouter(tag, record, fmtr)
+      return if fmtr.nil? || !fmtr.process_kubernetes_events
       if record.key?("event") && record["event"].respond_to?(:key?)
         if record.key?("verb")
           record["event"]["verb"] = record.delete("verb")

--- a/lib/fluent/plugin/filter_viaq_data_model_systemd.rb
+++ b/lib/fluent/plugin/filter_viaq_data_model_systemd.rb
@@ -68,7 +68,7 @@ module ViaqDataModelFilterSystemd
 
   JOURNAL_TIME_FIELDS = ['_SOURCE_REALTIME_TIMESTAMP', '__REALTIME_TIMESTAMP']
 
-  def process_journal_fields(tag, time, record, fmtr_type)
+  def process_journal_fields(tag, time, record, fmtr)
     systemd_t = {}
     JOURNAL_FIELD_MAP_SYSTEMD_T.each do |jkey, key|
       if record.key?(jkey)
@@ -104,7 +104,7 @@ module ViaqDataModelFilterSystemd
         break
       end
     end
-    case fmtr_type
+    case fmtr.type
     when :sys_journal
       record['message'] = record['MESSAGE']
       if record['_HOSTNAME'].eql?('localhost') && @docker_hostname
@@ -136,7 +136,7 @@ module ViaqDataModelFilterSystemd
       else
         record['hostname'] = record['_HOSTNAME']
       end
-      transform_eventrouter(tag, record)
+      transform_eventrouter(tag, record, fmtr)
     end
   end
 end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1756920
Add a per-formatter `process_kubernetes_events`.  This will
allow us to always have event processing enabled for eventrouter
logs, but disabled for everything else, assuming the user creates
eventrouter logs with a specific name, as specified in the docs.
For example, if the eventrouter is deployed with a pod name matching
`eventrouter-*`, we can do something like this:

```
    <filter **>
      @type viaq_data_model
      ...
      process_kubernetes_events false
      <formatter>
        tag "kubernetes.var.log.containers.eventrouter-**"
        type k8s_json_file
        remove_keys log,stream,CONTAINER_ID_FULL,CONTAINER_NAME
        process_kubernetes_events true
      </formatter>
      <formatter>
        tag "kubernetes.var.log.containers**"
        type k8s_json_file
        remove_keys log,stream,CONTAINER_ID_FULL,CONTAINER_NAME
      </formatter>
```

Then, we can have eventrouter processing on by default, always, with no
env. vars or api changes required.